### PR TITLE
Address feedback from Issue 4

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -340,4 +340,10 @@ wsl -e bash -lc "/home/jon/.fly/bin/flyctl ssh console -a transit-explorer"
 sqlite3 -header -column /app/tm-instance/data.db
 # now you have a full sqlite3 REPL — type any SQL, .quit to exit
 
+# Manually run pytests:
+
+C:\Users\Jonat\projects\tm-project-folder\transit-explorer\tm-frontend> wsl bash -c "cd /mnt/c/Users/Jonat/projects/tm-project-folder/transit-explorer && source .venv/bin/activate && pytest tests/ -q 2>&1 | tail -50"
+..............                                                           [100%]
+14 passed in 9.91s
+
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## What it is
 
 Transit Explorer turns riding transit into an exploration game. Pick a route,
-tap your boarding stop, tap your alighting stop — the segment lights up on
+tap your boarding stop, tap your ending stop — the segment lights up on
 your personal map. Over time you can see exactly which parts of the network
 you've ridden, and which you still haven't.
 
@@ -29,7 +29,7 @@ stay essentially free to host.
 
 - 🗺️ **Interactive map** of every route in the OneBusAway dataset, with
   per-direction polylines and stops.
-- 👆 **Tap-to-log rides** — mark the boarding stop, tap the alighting stop,
+- 👆 **Tap-to-log rides** — mark the boarding stop, tap the ending stop,
   and the segment is saved to your account.
 - 📈 **Per-route progress** — completion bars, recent activity feed, and a
   14-day rides sparkline.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -91,6 +91,14 @@ def create_app():
     # Initialize Firebase Admin SDK
     _init_firebase(app)
 
+    # Run alembic migrations (idempotent; self-heals legacy DBs that
+    # predate alembic). Must happen BEFORE we query any user tables in
+    # the data-init block below, otherwise a stale schema raises
+    # OperationalError on missing columns.
+    if os.getenv("SKIP_DB_UPGRADE", "0") != "1":
+        with app.app_context():
+            _run_migrations(app)
+
     # Register blueprints
     from app.routes.api import api_blueprint
     app.register_blueprint(api_blueprint, url_prefix="/api")
@@ -186,6 +194,53 @@ def _start_background_backfill(app):
 
     t = threading.Thread(target=_run, daemon=True, name="oba-backfill")
     t.start()
+
+
+# Baseline alembic revision — represents the schema as-of when alembic
+# was first introduced. Used to stamp legacy DBs whose tables were
+# created via `db.create_all()` before migrations existed.
+_ALEMBIC_BASELINE_REV = "f838d5f10e83"
+
+
+def _run_migrations(app):
+    """Bring the database schema up to date.
+
+    Self-heals two common situations:
+      1. Brand-new DB — `flask db upgrade` creates everything.
+      2. Legacy DB whose tables exist but `alembic_version` does not
+         (created via db.create_all() before alembic was added). We
+         stamp the baseline first so `upgrade` only applies *new*
+         migrations instead of re-running CREATE TABLEs.
+
+    Any failure is logged but does NOT prevent the app from starting,
+    so health checks can still respond while you investigate.
+    """
+    try:
+        from flask_migrate import stamp, upgrade
+
+        inspector = inspect(db.engine)
+        tables = set(inspector.get_table_names())
+
+        if not tables:
+            logger.info("[migrate] empty database — running full upgrade")
+        else:
+            has_app_tables = "user_segments" in tables or "routes" in tables
+            has_alembic = "alembic_version" in tables
+            if has_app_tables and not has_alembic:
+                logger.info(
+                    "[migrate] legacy DB detected (no alembic_version) — "
+                    "stamping baseline %s",
+                    _ALEMBIC_BASELINE_REV,
+                )
+                stamp(revision=_ALEMBIC_BASELINE_REV)
+
+        logger.info("[migrate] running flask db upgrade …")
+        upgrade()
+        logger.info("[migrate] migrations done")
+    except Exception:
+        logger.exception(
+            "[migrate] migration step failed — schema may be out of date"
+        )
 
 
 def _init_firebase(app):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -215,24 +215,38 @@ def _run_migrations(app):
     Any failure is logged but does NOT prevent the app from starting,
     so health checks can still respond while you investigate.
     """
+    # Tables that the baseline migration expects to create. If ANY of
+    # them already exist in a DB that has no alembic_version row, we
+    # treat the schema as legacy and stamp the baseline before
+    # running upgrade — otherwise alembic will try to re-CREATE them
+    # and SQLite will either error or lock.
+    BASELINE_TABLES = {
+        "routes",
+        "stops",
+        "users",
+        "route_directions",
+        "route_direction_stops",
+        "user_segments",
+    }
     try:
         from flask_migrate import stamp, upgrade
 
         inspector = inspect(db.engine)
         tables = set(inspector.get_table_names())
+        logger.info("[migrate] DB tables seen: %s", sorted(tables) or "<none>")
 
-        if not tables:
+        has_alembic = "alembic_version" in tables
+        legacy_tables = tables & BASELINE_TABLES
+        if legacy_tables and not has_alembic:
+            logger.info(
+                "[migrate] legacy DB detected (%d baseline tables, no "
+                "alembic_version) — stamping baseline %s",
+                len(legacy_tables),
+                _ALEMBIC_BASELINE_REV,
+            )
+            stamp(revision=_ALEMBIC_BASELINE_REV)
+        elif not tables:
             logger.info("[migrate] empty database — running full upgrade")
-        else:
-            has_app_tables = "user_segments" in tables or "routes" in tables
-            has_alembic = "alembic_version" in tables
-            if has_app_tables and not has_alembic:
-                logger.info(
-                    "[migrate] legacy DB detected (no alembic_version) — "
-                    "stamping baseline %s",
-                    _ALEMBIC_BASELINE_REV,
-                )
-                stamp(revision=_ALEMBIC_BASELINE_REV)
 
         logger.info("[migrate] running flask db upgrade …")
         upgrade()

--- a/app/migrations/versions/a1c2e4f9b701_add_user_segments_duration_ms.py
+++ b/app/migrations/versions/a1c2e4f9b701_add_user_segments_duration_ms.py
@@ -1,0 +1,25 @@
+"""add user_segments.duration_ms
+
+Revision ID: a1c2e4f9b701
+Revises: f838d5f10e83
+Create Date: 2026-04-21 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'a1c2e4f9b701'
+down_revision = 'f838d5f10e83'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user_segments') as batch_op:
+        batch_op.add_column(sa.Column('duration_ms', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('user_segments') as batch_op:
+        batch_op.drop_column('duration_ms')

--- a/app/migrations/versions/a1c2e4f9b701_add_user_segments_duration_ms.py
+++ b/app/migrations/versions/a1c2e4f9b701_add_user_segments_duration_ms.py
@@ -16,10 +16,22 @@ depends_on = None
 
 
 def upgrade():
+    # Idempotent: skip if the column already exists (e.g. legacy DBs
+    # where someone added it manually before stamping alembic).
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = {c['name'] for c in insp.get_columns('user_segments')}
+    if 'duration_ms' in cols:
+        return
     with op.batch_alter_table('user_segments') as batch_op:
         batch_op.add_column(sa.Column('duration_ms', sa.Integer(), nullable=True))
 
 
 def downgrade():
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = {c['name'] for c in insp.get_columns('user_segments')}
+    if 'duration_ms' not in cols:
+        return
     with op.batch_alter_table('user_segments') as batch_op:
         batch_op.drop_column('duration_ms')

--- a/app/migrations/versions/a1c2e4f9b701_add_user_segments_duration_ms.py
+++ b/app/migrations/versions/a1c2e4f9b701_add_user_segments_duration_ms.py
@@ -16,15 +16,19 @@ depends_on = None
 
 
 def upgrade():
-    # Idempotent: skip if the column already exists (e.g. legacy DBs
-    # where someone added it manually before stamping alembic).
+    # Idempotent + lock-friendly: a plain ADD COLUMN works natively on
+    # SQLite (no batch table copy) and on Postgres. batch_alter_table
+    # was hanging on a SQLite volume because it rewrites the whole
+    # table inside a transaction.
     bind = op.get_bind()
     insp = sa.inspect(bind)
     cols = {c['name'] for c in insp.get_columns('user_segments')}
     if 'duration_ms' in cols:
         return
-    with op.batch_alter_table('user_segments') as batch_op:
-        batch_op.add_column(sa.Column('duration_ms', sa.Integer(), nullable=True))
+    op.add_column(
+        'user_segments',
+        sa.Column('duration_ms', sa.Integer(), nullable=True),
+    )
 
 
 def downgrade():
@@ -33,5 +37,7 @@ def downgrade():
     cols = {c['name'] for c in insp.get_columns('user_segments')}
     if 'duration_ms' not in cols:
         return
+    # SQLite < 3.35 can't DROP COLUMN without a table rewrite; use
+    # batch mode only on the downgrade path where we have to.
     with op.batch_alter_table('user_segments') as batch_op:
         batch_op.drop_column('duration_ms')

--- a/app/models.py
+++ b/app/models.py
@@ -136,6 +136,10 @@ class UserSegment(db.Model):
     to_stop_id = db.Column(db.String(50), db.ForeignKey('stops.id'), nullable=False)
     completed_at = db.Column(db.DateTime, default=datetime.utcnow)
     notes = db.Column(db.Text)
+    # Optional measured trip duration in milliseconds. Captured client-side
+    # between the boarding and alighting taps; only ever set on the first
+    # row of a multi-segment run. Editable later via the API.
+    duration_ms = db.Column(db.Integer, nullable=True)
 
     route = db.relationship('Route', lazy='joined')
     from_stop = db.relationship('Stop', foreign_keys=[from_stop_id], lazy='joined')
@@ -158,4 +162,5 @@ class UserSegment(db.Model):
             'to_stop_name': self.to_stop.name if self.to_stop else None,
             'completed_at': self.completed_at.isoformat() if self.completed_at else None,
             'notes': self.notes,
+            'duration_ms': self.duration_ms,
         }

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -6,6 +6,7 @@ from app import db, limiter
 from app.auth import require_auth
 from app.validators import (
     validate_id, validate_direction_id, validate_notes, validate_id_list,
+    validate_duration_ms,
 )
 from datetime import datetime, timedelta
 import json
@@ -511,6 +512,7 @@ def mark_segments():
         from_stop_id = validate_id(data.get('from_stop_id'), 'from_stop_id')
         to_stop_id = validate_id(data.get('to_stop_id'), 'to_stop_id')
         notes = validate_notes(data.get('notes'))
+        duration_ms = validate_duration_ms(data.get('duration_ms'))
     except ValueError as ve:
         return jsonify({'error': str(ve)}), 400
 
@@ -568,6 +570,10 @@ def mark_segments():
             to_stop_id=b,
             completed_at=now,
             notes=notes if i == 0 else '',
+            # Attach the measured trip duration to the first row of the run.
+            # Subsequent rows keep duration_ms=NULL so we don't double-count
+            # in aggregates.
+            duration_ms=duration_ms if i == 0 else None,
         )
         db.session.add(segment)
         created.append(segment)
@@ -596,6 +602,29 @@ def update_segment_notes(segment_id):
     data = request.get_json(silent=True) or {}
     try:
         segment.notes = validate_notes(data.get('notes'))
+    except ValueError as ve:
+        return jsonify({'error': str(ve)}), 400
+    db.session.commit()
+    return jsonify(segment.to_dict())
+
+
+@api_blueprint.route('/me/segments/<int:segment_id>/duration', methods=['PUT'])
+@require_auth
+def update_segment_duration(segment_id):
+    """Edit (or clear) the measured trip duration on a single segment row.
+
+    Pass `duration_ms`: a non-negative integer of milliseconds, or `null`
+    to clear it.
+    """
+    user = g.current_user
+    segment = UserSegment.query.filter_by(id=segment_id, user_id=user.id).first()
+    if not segment:
+        return jsonify({'error': 'Segment not found'}), 404
+    data = request.get_json(silent=True) or {}
+    if 'duration_ms' not in data:
+        return jsonify({'error': 'duration_ms is required (use null to clear)'}), 400
+    try:
+        segment.duration_ms = validate_duration_ms(data.get('duration_ms'))
     except ValueError as ve:
         return jsonify({'error': str(ve)}), 400
     db.session.commit()

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -559,7 +559,11 @@ def mark_segments():
 
     created = []
     now = datetime.utcnow()
-    for i, (a, b) in enumerate(pair_keys):
+    # Attach the measured trip duration + notes to the first row we actually
+    # create (not the first pair_key), so duration isn't silently dropped
+    # when pair_keys[0] was already marked on an earlier ride.
+    first_new = True
+    for (a, b) in pair_keys:
         if (a, b) in existing:
             continue
         segment = UserSegment(
@@ -569,14 +573,12 @@ def mark_segments():
             from_stop_id=a,
             to_stop_id=b,
             completed_at=now,
-            notes=notes if i == 0 else '',
-            # Attach the measured trip duration to the first row of the run.
-            # Subsequent rows keep duration_ms=NULL so we don't double-count
-            # in aggregates.
-            duration_ms=duration_ms if i == 0 else None,
+            notes=notes if first_new else '',
+            duration_ms=duration_ms if first_new else None,
         )
         db.session.add(segment)
         created.append(segment)
+        first_new = False
 
     db.session.commit()
 

--- a/app/validators.py
+++ b/app/validators.py
@@ -12,6 +12,9 @@ _ID_RE = re.compile(r"^[A-Za-z0-9_\-\.:]{1,80}$")
 
 MAX_NOTES_LEN = 500
 MAX_BULK_IDS = 500
+# Cap measured trip duration at 24h to keep the int small and reject
+# obviously-bogus client clocks.
+MAX_DURATION_MS = 24 * 60 * 60 * 1000
 
 
 def validate_id(value, field):
@@ -44,6 +47,26 @@ def validate_notes(value, field="notes"):
     if len(v) > MAX_NOTES_LEN:
         raise ValueError(f"{field} exceeds {MAX_NOTES_LEN} characters")
     return v
+
+
+def validate_duration_ms(value, field="duration_ms", required=False):
+    """Optional measured trip duration in milliseconds.
+
+    Accepts None / missing (returns None) unless required=True. Rejects
+    negative, non-numeric, or absurdly large values.
+    """
+    if value is None:
+        if required:
+            raise ValueError(f"{field} is required")
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a number")
+    iv = int(value)
+    if iv < 0:
+        raise ValueError(f"{field} must be >= 0")
+    if iv > MAX_DURATION_MS:
+        raise ValueError(f"{field} exceeds maximum of {MAX_DURATION_MS}")
+    return iv
 
 
 def validate_id_list(value, field, max_len=MAX_BULK_IDS):

--- a/gunicorn_startup.sh
+++ b/gunicorn_startup.sh
@@ -48,43 +48,47 @@ APP_MODULE="app:create_app()"
 if [ "${SKIP_DB_UPGRADE:-0}" != "1" ]; then
     echo "Running database migrations..."
 
-    # Self-heal for legacy DBs that were created before Alembic was
-    # introduced: if the schema's already there but `alembic_version`
-    # isn't, stamp the baseline so `db upgrade` only applies *new*
-    # migrations instead of trying to re-CREATE existing tables.
-    BASELINE_REV="f838d5f10e83"
-    NEEDS_STAMP=$(FLASK_APP=app.py python3 - <<'PY'
-import os, sys
-try:
-    from app import create_app, db
-    from sqlalchemy import inspect
-    app = create_app()
-    with app.app_context():
-        insp = inspect(db.engine)
-        tables = set(insp.get_table_names())
-        if "user_segments" in tables and "alembic_version" not in tables:
-            print("yes")
-        else:
-            print("no")
-except Exception as e:
-    print(f"err:{e}", file=sys.stderr)
-    print("no")
-PY
-)
-    if [ "$NEEDS_STAMP" = "yes" ]; then
-        echo "  detected legacy DB without alembic_version — stamping baseline ($BASELINE_REV)"
-        FLASK_APP=app.py flask db stamp "$BASELINE_REV" || {
-            echo "  WARNING: db stamp failed — subsequent upgrade will likely error" >&2
-        }
-    fi
+    # Do detection + stamp + upgrade inside one Python invocation so
+    # we don't have to parse stdout (data loaders, logging, etc.) from
+    # `create_app()`. Self-heals legacy DBs created before Alembic was
+    # wired up: if app tables exist but `alembic_version` doesn't,
+    # stamp baseline first so `db upgrade` only applies *new* migrations
+    # instead of trying to re-CREATE existing tables.
+    SKIP_STARTUP_DATA_TASKS=1 FLASK_APP=app.py python3 - <<'PY' || {
+        echo "  WARNING: migration step failed — schema may be out of date" >&2
+    }
+import sys
+import logging
 
-    # Don't swallow real migration errors any more — let them surface
-    # in logs so a missing column doesn't masquerade as "no migrations
-    # to run". A non-zero exit still falls through to gunicorn so the
-    # container can serve health checks while you debug.
-    if ! FLASK_APP=app.py flask db upgrade; then
-        echo "  WARNING: 'flask db upgrade' returned non-zero — schema may be out of date" >&2
-    fi
+logging.basicConfig(level=logging.INFO, format="  [migrate] %(message)s")
+log = logging.getLogger("migrate")
+
+BASELINE_REV = "f838d5f10e83"
+
+from sqlalchemy import inspect
+from flask_migrate import stamp, upgrade
+from app import create_app, db
+
+app = create_app()
+with app.app_context():
+    insp = inspect(db.engine)
+    tables = set(insp.get_table_names())
+    legacy = "user_segments" in tables and "alembic_version" not in tables
+    if legacy:
+        log.info("legacy DB detected (no alembic_version) — stamping baseline %s", BASELINE_REV)
+        try:
+            stamp(revision=BASELINE_REV)
+        except Exception as e:
+            log.error("stamp failed: %s", e)
+            sys.exit(1)
+    log.info("running flask db upgrade …")
+    try:
+        upgrade()
+    except Exception as e:
+        log.error("upgrade failed: %s", e)
+        sys.exit(1)
+    log.info("migrations done")
+PY
 fi
 
 # ─── Preload transit data ─────────────────────────────────────

--- a/gunicorn_startup.sh
+++ b/gunicorn_startup.sh
@@ -44,13 +44,28 @@ LOG_LEVEL=${LOG_LEVEL:-info}
 BIND_ADDR="0.0.0.0:${FLASK_PORT}"
 APP_MODULE="app:create_app()"
 
-# ─── Database migrations ──────────────────────────────────────
-# Migrations now run inside `create_app()` itself (see app/__init__.py:
-# `_run_migrations`). That keeps the legacy-DB self-heal in plain
-# Python instead of a fragile bash heredoc, and means workers and the
-# preload phase all see the up-to-date schema.
-#
-# Set SKIP_DB_UPGRADE=1 to bypass it (handled by create_app).
+# ─── Database migrations (synchronous, exclusive) ─────────────
+# Run schema migrations BEFORE anything else touches the DB. This
+# guarantees no other connection can hold a write lock during ALTER
+# TABLE. Skip with SKIP_DB_UPGRADE=1.
+if [ "${SKIP_DB_UPGRADE:-0}" != "1" ]; then
+    echo "Running database migrations..."
+    SKIP_STARTUP_DATA_TASKS=1 SKIP_DB_UPGRADE=0 python3 - <<'PY'
+import logging
+logging.basicConfig(level=logging.INFO, format="  [migrate] %(message)s")
+from app import create_app
+# create_app() will invoke _run_migrations() once. SKIP_STARTUP_DATA_TASKS=1
+# prevents the data-init block from also touching the DB in the same process.
+create_app()
+PY
+fi
+
+# Tell create_app() in subsequent processes (preload script + gunicorn
+# master) NOT to run migrations again — we just did them.
+export SKIP_DB_UPGRADE=1
+
+# ─── Preload transit data ─────────────────────────────────────
+# Treat SKIP_DATA_LOAD and SKIP_STARTUP_DATA_TASKS as aliases.
 
 # ─── Preload transit data ─────────────────────────────────────
 # Treat SKIP_DATA_LOAD and SKIP_STARTUP_DATA_TASKS as aliases.

--- a/gunicorn_startup.sh
+++ b/gunicorn_startup.sh
@@ -44,52 +44,13 @@ LOG_LEVEL=${LOG_LEVEL:-info}
 BIND_ADDR="0.0.0.0:${FLASK_PORT}"
 APP_MODULE="app:create_app()"
 
-# ─── Run database migrations ──────────────────────────────────
-if [ "${SKIP_DB_UPGRADE:-0}" != "1" ]; then
-    echo "Running database migrations..."
-
-    # Do detection + stamp + upgrade inside one Python invocation so
-    # we don't have to parse stdout (data loaders, logging, etc.) from
-    # `create_app()`. Self-heals legacy DBs created before Alembic was
-    # wired up: if app tables exist but `alembic_version` doesn't,
-    # stamp baseline first so `db upgrade` only applies *new* migrations
-    # instead of trying to re-CREATE existing tables.
-    SKIP_STARTUP_DATA_TASKS=1 FLASK_APP=app.py python3 - <<'PY' || {
-        echo "  WARNING: migration step failed — schema may be out of date" >&2
-    }
-import sys
-import logging
-
-logging.basicConfig(level=logging.INFO, format="  [migrate] %(message)s")
-log = logging.getLogger("migrate")
-
-BASELINE_REV = "f838d5f10e83"
-
-from sqlalchemy import inspect
-from flask_migrate import stamp, upgrade
-from app import create_app, db
-
-app = create_app()
-with app.app_context():
-    insp = inspect(db.engine)
-    tables = set(insp.get_table_names())
-    legacy = "user_segments" in tables and "alembic_version" not in tables
-    if legacy:
-        log.info("legacy DB detected (no alembic_version) — stamping baseline %s", BASELINE_REV)
-        try:
-            stamp(revision=BASELINE_REV)
-        except Exception as e:
-            log.error("stamp failed: %s", e)
-            sys.exit(1)
-    log.info("running flask db upgrade …")
-    try:
-        upgrade()
-    except Exception as e:
-        log.error("upgrade failed: %s", e)
-        sys.exit(1)
-    log.info("migrations done")
-PY
-fi
+# ─── Database migrations ──────────────────────────────────────
+# Migrations now run inside `create_app()` itself (see app/__init__.py:
+# `_run_migrations`). That keeps the legacy-DB self-heal in plain
+# Python instead of a fragile bash heredoc, and means workers and the
+# preload phase all see the up-to-date schema.
+#
+# Set SKIP_DB_UPGRADE=1 to bypass it (handled by create_app).
 
 # ─── Preload transit data ─────────────────────────────────────
 # Treat SKIP_DATA_LOAD and SKIP_STARTUP_DATA_TASKS as aliases.

--- a/gunicorn_startup.sh
+++ b/gunicorn_startup.sh
@@ -47,8 +47,43 @@ APP_MODULE="app:create_app()"
 # ─── Run database migrations ──────────────────────────────────
 if [ "${SKIP_DB_UPGRADE:-0}" != "1" ]; then
     echo "Running database migrations..."
-    if ! FLASK_APP=app.py flask db upgrade 2>/dev/null; then
-        echo "  (no migrations to run, or migrations not initialized — continuing)"
+
+    # Self-heal for legacy DBs that were created before Alembic was
+    # introduced: if the schema's already there but `alembic_version`
+    # isn't, stamp the baseline so `db upgrade` only applies *new*
+    # migrations instead of trying to re-CREATE existing tables.
+    BASELINE_REV="f838d5f10e83"
+    NEEDS_STAMP=$(FLASK_APP=app.py python3 - <<'PY'
+import os, sys
+try:
+    from app import create_app, db
+    from sqlalchemy import inspect
+    app = create_app()
+    with app.app_context():
+        insp = inspect(db.engine)
+        tables = set(insp.get_table_names())
+        if "user_segments" in tables and "alembic_version" not in tables:
+            print("yes")
+        else:
+            print("no")
+except Exception as e:
+    print(f"err:{e}", file=sys.stderr)
+    print("no")
+PY
+)
+    if [ "$NEEDS_STAMP" = "yes" ]; then
+        echo "  detected legacy DB without alembic_version — stamping baseline ($BASELINE_REV)"
+        FLASK_APP=app.py flask db stamp "$BASELINE_REV" || {
+            echo "  WARNING: db stamp failed — subsequent upgrade will likely error" >&2
+        }
+    fi
+
+    # Don't swallow real migration errors any more — let them surface
+    # in logs so a missing column doesn't masquerade as "no migrations
+    # to run". A non-zero exit still falls through to gunicorn so the
+    # container can serve health checks while you debug.
+    if ! FLASK_APP=app.py flask db upgrade; then
+        echo "  WARNING: 'flask db upgrade' returned non-zero — schema may be out of date" >&2
     fi
 fi
 

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -81,3 +81,72 @@ def test_mark_segments_rejects_missing_stop(client, auth_headers, seeded_route):
         headers=auth_headers,
     )
     assert r.status_code == 400
+
+
+def test_mark_segments_persists_duration_on_first_row(client, auth_headers, seeded_route):
+    """duration_ms on a fresh multi-hop mark attaches to the first new row."""
+    stops = seeded_route["stops"]
+    r = client.post(
+        "/api/me/segments",
+        json={
+            "route_id": seeded_route["route"].id,
+            "direction_id": "0",
+            "from_stop_id": stops[0].id,
+            "to_stop_id": stops[2].id,
+            "duration_ms": 123456,
+        },
+        headers=auth_headers,
+    )
+    assert r.status_code == 201
+    body = r.get_json()
+    assert body["created"] == 2
+    segs = body["segments"]
+    assert segs[0]["duration_ms"] == 123456
+    assert segs[1]["duration_ms"] is None
+
+
+def test_mark_segments_attaches_duration_to_first_new_row(client, auth_headers, seeded_route):
+    """If pair_keys[0] was already marked, duration_ms must still land on
+    the first *newly created* segment rather than being silently dropped."""
+    stops = seeded_route["stops"]
+    # Pre-mark the first hop only (no duration).
+    r0 = client.post(
+        "/api/me/segments",
+        json={
+            "route_id": seeded_route["route"].id,
+            "direction_id": "0",
+            "from_stop_id": stops[0].id,
+            "to_stop_id": stops[1].id,
+        },
+        headers=auth_headers,
+    )
+    assert r0.status_code == 201
+    assert r0.get_json()["created"] == 1
+
+    # Now mark the full run with a measured duration. The first pair is
+    # already present, so only the second pair is newly created -- the
+    # duration must attach to that new row.
+    r1 = client.post(
+        "/api/me/segments",
+        json={
+            "route_id": seeded_route["route"].id,
+            "direction_id": "0",
+            "from_stop_id": stops[0].id,
+            "to_stop_id": stops[2].id,
+            "duration_ms": 98765,
+        },
+        headers=auth_headers,
+    )
+    assert r1.status_code == 201
+    body = r1.get_json()
+    assert body["created"] == 1
+    assert body["skipped"] == 1
+    assert body["segments"][0]["duration_ms"] == 98765
+
+    # Progress endpoint surfaces the duration on the correct row so the
+    # frontend's journey grouping can find it.
+    pg = client.get("/api/me/progress", headers=auth_headers)
+    assert pg.status_code == 200
+    route_progress = pg.get_json()["progress"][0]
+    durations = [s["duration_ms"] for s in route_progress["segments"]]
+    assert 98765 in durations

--- a/tm-frontend/src/App.jsx
+++ b/tm-frontend/src/App.jsx
@@ -156,6 +156,22 @@ function App() {
     if (user) loadUserData();
   }, [user, loadUserData]);
 
+  // The "📍 Viewing segment from progress" banner only makes sense while the
+  // user is still on the Progress tab looking at the highlighted route.
+  // Clear it as soon as they navigate to another tab or switch to a route
+  // other than the highlighted one — otherwise the banner sticks around
+  // forever even though the context is gone.
+  useEffect(() => {
+    if (!highlightedSegment) return;
+    if (activeTab !== "progress") {
+      setHighlightedSegment(null);
+      return;
+    }
+    if (selectedRoute && selectedRoute.id !== highlightedSegment.routeId) {
+      setHighlightedSegment(null);
+    }
+  }, [activeTab, selectedRoute, highlightedSegment]);
+
   if (authLoading || loading) {
     return (
       <div className="app">

--- a/tm-frontend/src/components/HelpModal.jsx
+++ b/tm-frontend/src/components/HelpModal.jsx
@@ -38,39 +38,39 @@ function HelpModal({ open, onClose, onDontShowAgain }) {
           🚌 How to log a ride
         </h2>
         <p className="help-modal-lead">
-          Three taps on the map turn the route line green. Watch for the
-          glow — that means the segment was just saved.
+          Three taps on the map turn the route line green. Watch for the glow —
+          that means the segment was just saved.
         </p>
 
         <ol className="help-modal-steps">
           <li>
             <span className="help-modal-num">1</span>
             <div>
-              <strong>Pick a route</strong> from the sidebar. The full
-              route appears on the map.
+              <strong>Pick a route</strong> from the sidebar. The full route
+              appears on the map.
             </div>
           </li>
           <li>
             <span className="help-modal-num">2</span>
             <div>
-              <strong>Choose your direction</strong> using the tabs above
-              the legend (e.g. <em>Toward Downtown</em>). The map only
-              shows stops in that direction.
+              <strong>Choose your direction</strong> using the tabs above the
+              legend (e.g. <em>Toward Downtown</em>). The map only shows stops
+              in that direction.
             </div>
           </li>
           <li>
             <span className="help-modal-num">3</span>
             <div>
-              <strong>Tap your boarding stop</strong>. It turns into a
-              pulsing yellow marker.
+              <strong>Tap your boarding stop</strong>. It turns into a pulsing
+              yellow marker.
             </div>
           </li>
           <li>
             <span className="help-modal-num">4</span>
             <div>
-              <strong>Tap your alighting stop</strong> — anywhere ahead
-              on the same direction. Every hop in between turns green
-              and is added to your progress.
+              <strong>Tap your alighting stop</strong> — anywhere ahead on the
+              same direction. Every hop in between turns green and is added to
+              your progress.
             </div>
           </li>
         </ol>
@@ -79,14 +79,14 @@ function HelpModal({ open, onClose, onDontShowAgain }) {
           <strong>When should I log?</strong> Either works:
           <ul>
             <li>
-              <strong>Tap-and-go:</strong> tap your boarding stop when
-              you board, then tap the alighting stop when you get off.
-              The app tracks your trip time between taps.
+              <strong>Tap-and-go:</strong> tap your boarding stop when you
+              board, then tap the alighting stop when you get off. The app
+              tracks your trip time between taps.
             </li>
             <li>
-              <strong>After the fact:</strong> tap both stops back-to-back
-              once you&apos;ve arrived. You won&apos;t get a trip-time
-              measurement, but the segments still count.
+              <strong>After the fact:</strong> tap both stops back-to-back once
+              you&apos;ve arrived. You won&apos;t get a trip-time measurement,
+              but the segments still count.
             </li>
           </ul>
         </div>
@@ -95,7 +95,9 @@ function HelpModal({ open, onClose, onDontShowAgain }) {
           <strong>Shortcuts</strong>
           <ul>
             <li>Tap any line directly to mark just that one hop.</li>
-            <li>Press <kbd>Esc</kbd> or hit <em>Undo boarding</em> to cancel.</li>
+            <li>
+              Press <kbd>Esc</kbd> or hit <em>Undo boarding</em> to cancel.
+            </li>
             <li>Use the search box to jump to a stop by name.</li>
           </ul>
         </div>

--- a/tm-frontend/src/components/HelpModal.jsx
+++ b/tm-frontend/src/components/HelpModal.jsx
@@ -1,0 +1,127 @@
+import React, { useEffect } from "react";
+
+/**
+ * Onboarding / how-to-use-the-map modal. Shown automatically the first
+ * time a signed-in user lands on the app, and re-openable from the
+ * floating "?" button on the map.
+ */
+function HelpModal({ open, onClose, onDontShowAgain }) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="help-modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="help-modal-title"
+      onClick={onClose}
+    >
+      <div className="help-modal" onClick={(e) => e.stopPropagation()}>
+        <button
+          type="button"
+          className="help-modal-close"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          ✕
+        </button>
+        <h2 id="help-modal-title" className="help-modal-title">
+          🚌 How to log a ride
+        </h2>
+        <p className="help-modal-lead">
+          Three taps on the map turn the route line green. Watch for the
+          glow — that means the segment was just saved.
+        </p>
+
+        <ol className="help-modal-steps">
+          <li>
+            <span className="help-modal-num">1</span>
+            <div>
+              <strong>Pick a route</strong> from the sidebar. The full
+              route appears on the map.
+            </div>
+          </li>
+          <li>
+            <span className="help-modal-num">2</span>
+            <div>
+              <strong>Choose your direction</strong> using the tabs above
+              the legend (e.g. <em>Toward Downtown</em>). The map only
+              shows stops in that direction.
+            </div>
+          </li>
+          <li>
+            <span className="help-modal-num">3</span>
+            <div>
+              <strong>Tap your boarding stop</strong>. It turns into a
+              pulsing yellow marker.
+            </div>
+          </li>
+          <li>
+            <span className="help-modal-num">4</span>
+            <div>
+              <strong>Tap your alighting stop</strong> — anywhere ahead
+              on the same direction. Every hop in between turns green
+              and is added to your progress.
+            </div>
+          </li>
+        </ol>
+
+        <div className="help-modal-tip">
+          <strong>When should I log?</strong> Either works:
+          <ul>
+            <li>
+              <strong>Tap-and-go:</strong> tap your boarding stop when
+              you board, then tap the alighting stop when you get off.
+              The app tracks your trip time between taps.
+            </li>
+            <li>
+              <strong>After the fact:</strong> tap both stops back-to-back
+              once you&apos;ve arrived. You won&apos;t get a trip-time
+              measurement, but the segments still count.
+            </li>
+          </ul>
+        </div>
+
+        <div className="help-modal-tip">
+          <strong>Shortcuts</strong>
+          <ul>
+            <li>Tap any line directly to mark just that one hop.</li>
+            <li>Press <kbd>Esc</kbd> or hit <em>Undo boarding</em> to cancel.</li>
+            <li>Use the search box to jump to a stop by name.</li>
+          </ul>
+        </div>
+
+        <div className="help-modal-actions">
+          <button
+            type="button"
+            className="help-modal-secondary"
+            onClick={() => {
+              onDontShowAgain?.();
+              onClose?.();
+            }}
+          >
+            Don&apos;t show this again
+          </button>
+          <button
+            type="button"
+            className="help-modal-primary"
+            onClick={onClose}
+          >
+            Got it
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default HelpModal;

--- a/tm-frontend/src/components/HelpModal.jsx
+++ b/tm-frontend/src/components/HelpModal.jsx
@@ -68,9 +68,9 @@ function HelpModal({ open, onClose, onDontShowAgain }) {
           <li>
             <span className="help-modal-num">4</span>
             <div>
-              <strong>Tap your alighting stop</strong> — anywhere ahead on the
-              same direction. Every hop in between turns green and is added to
-              your progress.
+              <strong>Tap your ending stop</strong> — anywhere ahead on the same
+              direction. Every hop in between turns green and is added to your
+              progress.
             </div>
           </li>
         </ol>
@@ -80,8 +80,8 @@ function HelpModal({ open, onClose, onDontShowAgain }) {
           <ul>
             <li>
               <strong>Tap-and-go:</strong> tap your boarding stop when you
-              board, then tap the alighting stop when you get off. The app
-              tracks your trip time between taps.
+              board, then tap the ending stop when you get off. The app tracks
+              your trip time between taps.
             </li>
             <li>
               <strong>After the fact:</strong> tap both stops back-to-back once

--- a/tm-frontend/src/components/TransitMap.jsx
+++ b/tm-frontend/src/components/TransitMap.jsx
@@ -711,7 +711,7 @@ function TransitMap({
         {visibleStops.map((stop) => {
           const isPicking = pickState?.directionId === stop.directionId;
           const isFrom = isPicking && pickState?.fromStopId === stop.id;
-          // A stop is a valid alighting candidate only if it sits *after* the
+          // A stop is a valid ending candidate only if it sits *after* the
           // boarding stop in the direction's stop order.
           const isValidCandidate =
             isPicking &&
@@ -859,7 +859,7 @@ function TransitMap({
                   className="stop-search-input"
                   placeholder={
                     pickState
-                      ? "Find your alighting stop…"
+                      ? "Find your ending stop…"
                       : "Find a stop on this route…"
                   }
                   value={stopSearch}
@@ -896,7 +896,7 @@ function TransitMap({
                             isBoardingChoice
                               ? "This is your boarding stop"
                               : pickState
-                                ? "Mark as alighting stop"
+                                ? "Mark as ending stop"
                                 : "Board here"
                           }
                         >
@@ -1044,7 +1044,7 @@ function TransitMap({
                     <span>
                       {justCompleted
                         ? "Trip logged — pick another or change direction"
-                        : "Tap your alighting stop in the same direction"}
+                        : "Tap your ending stop in the same direction"}
                     </span>
                   </div>
                 </div>
@@ -1066,7 +1066,7 @@ function TransitMap({
               {!legendCollapsed && tripStats && (
                 <div
                   className="map-legend-trip-stats"
-                  title="Average and most-recent ride time, measured between your boarding and alighting taps. Stored locally on this device."
+                  title="Average and most-recent ride time, measured between your boarding and ending taps. Stored locally on this device."
                 >
                   <span className="map-legend-trip-icon" aria-hidden>
                     ⏱
@@ -1110,7 +1110,7 @@ function TransitMap({
             </span>
           </div>
           <span className="pick-arrow">→</span>
-          <span className="pick-prompt">Now tap your alighting stop</span>
+          <span className="pick-prompt">Now tap your ending stop</span>
           {pickState.boardedAt && (
             <span
               className="pick-timer"

--- a/tm-frontend/src/components/TransitMap.jsx
+++ b/tm-frontend/src/components/TransitMap.jsx
@@ -381,23 +381,6 @@ function TransitMap({
     return seg ? [...seg.positions] : null;
   }, [highlightedSegment, directionSegments]);
 
-  const completionStats = useMemo(() => {
-    if (!directionSegments.length) return null;
-    const done = directionSegments.filter((s) =>
-      effectiveCompleted.has(s.key),
-    ).length;
-    return { done, total: directionSegments.length };
-  }, [directionSegments, effectiveCompleted]);
-
-  // Trip-time stats are stored client-side per (route, direction). We
-  // depend on tripStatsTick so the legend re-reads localStorage after
-  // each successful save.
-  const tripStats = useMemo(() => {
-    if (!routeDetail || activeDirection == null) return null;
-    return getTripStats(routeDetail.id, activeDirection);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeDetail, activeDirection, tripStatsTick]);
-
   // Reset optimistic completion state whenever the selected route changes.
   useEffect(() => {
     setOptimisticDone(new Set());
@@ -426,6 +409,23 @@ function TransitMap({
     for (const k of optimisticDone) merged.add(k);
     return merged;
   }, [completedSegments, optimisticDone]);
+
+  const completionStats = useMemo(() => {
+    if (!directionSegments.length) return null;
+    const done = directionSegments.filter((s) =>
+      effectiveCompleted.has(s.key),
+    ).length;
+    return { done, total: directionSegments.length };
+  }, [directionSegments, effectiveCompleted]);
+
+  // Trip-time stats are stored client-side per (route, direction). We
+  // depend on tripStatsTick so the legend re-reads localStorage after
+  // each successful save.
+  const tripStats = useMemo(() => {
+    if (!routeDetail || activeDirection == null) return null;
+    return getTripStats(routeDetail.id, activeDirection);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [routeDetail, activeDirection, tripStatsTick]);
 
   const submitMark = async (directionId, fromStopId, toStopId) => {
     if (!routeDetail) return;
@@ -668,7 +668,9 @@ function TransitMap({
             <React.Fragment key={seg.key}>
               <Polyline
                 positions={seg.positions}
-                color={isHighlighted ? "#facc15" : done ? "#22c55e" : routeColor}
+                color={
+                  isHighlighted ? "#facc15" : done ? "#22c55e" : routeColor
+                }
                 weight={isHighlighted ? 8 : done ? 6 : isHovered ? 6 : 4}
                 opacity={isHighlighted ? 1 : done ? 1 : isHovered ? 0.95 : 0.55}
                 eventHandlers={{

--- a/tm-frontend/src/components/TransitMap.jsx
+++ b/tm-frontend/src/components/TransitMap.jsx
@@ -477,11 +477,17 @@ function TransitMap({
 
     setMarking(true);
     try {
+      // Only send a duration to the server when we actually measured a
+      // live boarding -> alighting trip (>5s). After-the-fact taps leave
+      // duration_ms NULL on the new segment row.
+      const sendDuration = tripMs && tripMs > 5000 ? tripMs : null;
       const result = await markSegments(
         routeDetail.id,
         directionId,
         fromStopId,
         toStopId,
+        "",
+        sendDuration,
       );
       setPickState(null);
       onSegmentsMarked(result);

--- a/tm-frontend/src/components/TransitMap.jsx
+++ b/tm-frontend/src/components/TransitMap.jsx
@@ -751,7 +751,7 @@ function TransitMap({
                 <Tooltip direction="top" offset={[0, -14]} opacity={0.95}>
                   <span style={{ fontWeight: 600 }}>{stop.name}</span>
                   <br />
-                  <span style={{ fontSize: 11, color: "#facc15" }}>
+                  <span style={{ fontSize: 11, color: "#22c55e" }}>
                     Boarding stop — tap a stop ahead (toward{" "}
                     {activeDirectionMeta?.lastStopName || "destination"})
                   </span>

--- a/tm-frontend/src/components/TransitMap.jsx
+++ b/tm-frontend/src/components/TransitMap.jsx
@@ -11,8 +11,64 @@ import {
 import L from "leaflet";
 import polyline from "@mapbox/polyline";
 import { fetchRouteDetail, markSegments } from "../services/api";
+import HelpModal from "./HelpModal";
 
 const SEATTLE_CENTER = [47.6062, -122.3321];
+
+const HELP_SEEN_KEY = "te-help-seen-v1";
+const TRIP_TIMES_KEY = "te-trip-times-v1";
+const TRIP_TIMES_MAX = 25; // keep at most N samples per route+direction
+
+function readTripTimes() {
+  try {
+    const raw = localStorage.getItem(TRIP_TIMES_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function recordTripTime(routeId, directionId, ms) {
+  if (!routeId || ms == null || ms <= 0) return null;
+  const all = readTripTimes();
+  const key = `${routeId}|${directionId}`;
+  const list = Array.isArray(all[key]) ? all[key] : [];
+  list.push(Math.round(ms));
+  const trimmed = list.slice(-TRIP_TIMES_MAX);
+  all[key] = trimmed;
+  try {
+    localStorage.setItem(TRIP_TIMES_KEY, JSON.stringify(all));
+  } catch {
+    /* storage full / disabled — ignore */
+  }
+  return trimmed;
+}
+
+function getTripStats(routeId, directionId) {
+  const all = readTripTimes();
+  const list = all[`${routeId}|${directionId}`] || [];
+  if (!list.length) return null;
+  const total = list.reduce((a, b) => a + b, 0);
+  return {
+    count: list.length,
+    avgMs: total / list.length,
+    lastMs: list[list.length - 1],
+  };
+}
+
+function formatDuration(ms) {
+  if (!ms || ms <= 0) return null;
+  const totalSec = Math.round(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min < 60) return sec ? `${min}m ${sec}s` : `${min}m`;
+  const hr = Math.floor(min / 60);
+  const remMin = min % 60;
+  return remMin ? `${hr}h ${remMin}m` : `${hr}h`;
+}
 
 const ROUTE_TYPE_LABELS = {
   0: "Link",
@@ -98,8 +154,15 @@ function TransitMap({
   const [stopSearch, setStopSearch] = useState("");
   const [legendCollapsed, setLegendCollapsed] = useState(false);
   const [justCompleted, setJustCompleted] = useState(false);
+  const [optimisticDone, setOptimisticDone] = useState(() => new Set());
+  const [recentlyDone, setRecentlyDone] = useState(() => new Set());
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [tripStatsTick, setTripStatsTick] = useState(0); // bumps to refresh avg
+  const [liveTripMs, setLiveTripMs] = useState(0);
   const toastTimerRef = useRef(null);
   const completedTimerRef = useRef(null);
+  const recentTimerRef = useRef(null);
+  const liveTimerRef = useRef(null);
   const mapRef = useRef(null);
   const stopMarkerRefs = useRef({});
   const isMobile =
@@ -128,9 +191,45 @@ function TransitMap({
     () => () => {
       if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
       if (completedTimerRef.current) clearTimeout(completedTimerRef.current);
+      if (recentTimerRef.current) clearTimeout(recentTimerRef.current);
+      if (liveTimerRef.current) clearInterval(liveTimerRef.current);
     },
     [],
   );
+
+  // First-visit help: show the modal automatically until the user dismisses
+  // it once. After that they can re-open it with the "?" button on the map.
+  useEffect(() => {
+    try {
+      const seen = localStorage.getItem(HELP_SEEN_KEY);
+      if (!seen) setHelpOpen(true);
+    } catch {
+      /* localStorage disabled — skip auto-open */
+    }
+  }, []);
+
+  // Live "elapsed since boarding" counter that drives the on-bus timer
+  // shown in the pick overlay. Only runs while a boarding pick is active.
+  useEffect(() => {
+    if (liveTimerRef.current) {
+      clearInterval(liveTimerRef.current);
+      liveTimerRef.current = null;
+    }
+    if (pickState?.boardedAt) {
+      setLiveTripMs(Date.now() - pickState.boardedAt);
+      liveTimerRef.current = setInterval(() => {
+        setLiveTripMs(Date.now() - pickState.boardedAt);
+      }, 1000);
+    } else {
+      setLiveTripMs(0);
+    }
+    return () => {
+      if (liveTimerRef.current) {
+        clearInterval(liveTimerRef.current);
+        liveTimerRef.current = null;
+      }
+    };
+  }, [pickState]);
 
   // On phones, auto-collapse the legend when the user is mid-pick so the
   // bottom pick prompt doesn't fight with the legend's step list for space.
@@ -285,13 +384,97 @@ function TransitMap({
   const completionStats = useMemo(() => {
     if (!directionSegments.length) return null;
     const done = directionSegments.filter((s) =>
-      completedSegments.has(s.key),
+      effectiveCompleted.has(s.key),
     ).length;
     return { done, total: directionSegments.length };
-  }, [directionSegments, completedSegments]);
+  }, [directionSegments, effectiveCompleted]);
+
+  // Trip-time stats are stored client-side per (route, direction). We
+  // depend on tripStatsTick so the legend re-reads localStorage after
+  // each successful save.
+  const tripStats = useMemo(() => {
+    if (!routeDetail || activeDirection == null) return null;
+    return getTripStats(routeDetail.id, activeDirection);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [routeDetail, activeDirection, tripStatsTick]);
+
+  // Reset optimistic completion state whenever the selected route changes.
+  useEffect(() => {
+    setOptimisticDone(new Set());
+    setRecentlyDone(new Set());
+  }, [selectedRoute]);
+
+  // Drop optimistic keys once the server-confirmed prop set covers them.
+  useEffect(() => {
+    if (optimisticDone.size === 0) return;
+    let changed = false;
+    const next = new Set();
+    for (const key of optimisticDone) {
+      if (!completedSegments.has(key)) {
+        next.add(key);
+      } else {
+        changed = true;
+      }
+    }
+    if (changed) setOptimisticDone(next);
+  }, [completedSegments, optimisticDone]);
+
+  // The set the polylines actually paint against. Server truth ∪ optimistic.
+  const effectiveCompleted = useMemo(() => {
+    if (optimisticDone.size === 0) return completedSegments;
+    const merged = new Set(completedSegments);
+    for (const k of optimisticDone) merged.add(k);
+    return merged;
+  }, [completedSegments, optimisticDone]);
 
   const submitMark = async (directionId, fromStopId, toStopId) => {
     if (!routeDetail) return;
+
+    // Capture trip-time + boarding context BEFORE we clear pickState so we
+    // can record an accurate duration and pre-paint the segments green.
+    const boardedAt = pickState?.boardedAt || null;
+    const tripMs = boardedAt ? Date.now() - boardedAt : null;
+
+    // Build the list of optimistic keys for the entire run from -> to. The
+    // backend creates one segment per consecutive stop pair, so we mirror
+    // that here so the line turns green immediately on click.
+    const optimisticKeys = [];
+    const dir = (routeDetail.directions || []).find(
+      (d) => d.direction_id === directionId,
+    );
+    if (dir) {
+      const ids = dir.stop_ids || [];
+      const a = ids.indexOf(fromStopId);
+      const b = ids.indexOf(toStopId);
+      if (a !== -1 && b !== -1) {
+        const lo = Math.min(a, b);
+        const hi = Math.max(a, b);
+        for (let i = lo; i < hi; i++) {
+          optimisticKeys.push(
+            `${routeDetail.id}|${directionId}|${ids[i]}|${ids[i + 1]}`,
+          );
+        }
+      }
+    }
+    if (optimisticKeys.length) {
+      setOptimisticDone((prev) => {
+        const next = new Set(prev);
+        for (const k of optimisticKeys) next.add(k);
+        return next;
+      });
+      // Trigger the "just-turned-green" pulse animation.
+      setRecentlyDone((prev) => {
+        const next = new Set(prev);
+        for (const k of optimisticKeys) next.add(k);
+        return next;
+      });
+      if (recentTimerRef.current) clearTimeout(recentTimerRef.current);
+      recentTimerRef.current = setTimeout(() => {
+        setRecentlyDone(new Set());
+        recentTimerRef.current = null;
+      }, 1600);
+    }
+
     setMarking(true);
     try {
       const result = await markSegments(
@@ -301,10 +484,19 @@ function TransitMap({
         toStopId,
       );
       setPickState(null);
-      onSegmentsMarked();
+      onSegmentsMarked(result);
       const created = result.created ?? 0;
       const skipped = result.skipped ?? 0;
       if (created > 0) {
+        // Persist the trip duration if we measured one (boarding was
+        // tapped live, not after-the-fact).
+        let tripMsg = "";
+        if (tripMs && tripMs > 5000) {
+          recordTripTime(routeDetail.id, directionId, tripMs);
+          setTripStatsTick((t) => t + 1);
+          const f = formatDuration(tripMs);
+          if (f) tripMsg = ` · ${f} on bus`;
+        }
         // Briefly mark step 3 as complete so the user sees the full
         // 1-2-3 progression before the legend snaps back to step 1.
         if (completedTimerRef.current) clearTimeout(completedTimerRef.current);
@@ -315,7 +507,8 @@ function TransitMap({
         }, 1600);
         showToast(
           `✓ Marked ${created} segment${created > 1 ? "s" : ""}` +
-            (skipped ? ` · ${skipped} already done` : ""),
+            (skipped ? ` · ${skipped} already done` : "") +
+            tripMsg,
         );
       } else {
         showToast("All hops already marked", "info");
@@ -326,6 +519,19 @@ function TransitMap({
         );
       }
     } catch (err) {
+      // Roll back the optimistic paint if the server rejected the mark.
+      if (optimisticKeys.length) {
+        setOptimisticDone((prev) => {
+          const next = new Set(prev);
+          for (const k of optimisticKeys) next.delete(k);
+          return next;
+        });
+        setRecentlyDone((prev) => {
+          const next = new Set(prev);
+          for (const k of optimisticKeys) next.delete(k);
+          return next;
+        });
+      }
       showToast(err.message || "Could not save segment", "error");
     } finally {
       setMarking(false);
@@ -335,7 +541,12 @@ function TransitMap({
   const handleStopClick = (directionId, stopId, stopName) => {
     if (!routeDetail || marking) return;
     if (!pickState) {
-      setPickState({ directionId, fromStopId: stopId, fromName: stopName });
+      setPickState({
+        directionId,
+        fromStopId: stopId,
+        fromName: stopName,
+        boardedAt: Date.now(),
+      });
       return;
     }
 
@@ -362,7 +573,7 @@ function TransitMap({
   // Click a polyline directly to mark just that one hop.
   const handleSegmentClick = (seg) => {
     if (marking) return;
-    if (completedSegments.has(seg.key)) {
+    if (effectiveCompleted.has(seg.key)) {
       showToast("Already marked", "info");
       return;
     }
@@ -446,36 +657,52 @@ function TransitMap({
         {/* Two passes: faint background line, bold colored overlay.
              Lets completed hops glow on top of the route base. */}
         {directionSegments.map((seg) => {
-          const done = completedSegments.has(seg.key);
+          const done = effectiveCompleted.has(seg.key);
           const isHighlighted =
             highlightedSegment &&
             seg.key ===
               `${highlightedSegment.routeId}|${highlightedSegment.directionId}|${highlightedSegment.fromStopId}|${highlightedSegment.toStopId}`;
           const isHovered = hoverSeg === seg.key;
+          const isFresh = recentlyDone.has(seg.key);
           return (
-            <Polyline
-              key={seg.key}
-              positions={seg.positions}
-              color={isHighlighted ? "#facc15" : done ? "#22c55e" : routeColor}
-              weight={isHighlighted ? 8 : done ? 6 : isHovered ? 6 : 4}
-              opacity={isHighlighted ? 1 : done ? 1 : isHovered ? 0.95 : 0.55}
-              eventHandlers={{
-                click: () => handleSegmentClick(seg),
-                mouseover: () => setHoverSeg(seg.key),
-                mouseout: () => setHoverSeg((h) => (h === seg.key ? null : h)),
-              }}
-            >
-              <Tooltip sticky direction="top" opacity={0.95}>
-                <div style={{ fontWeight: 600, fontSize: 12 }}>
-                  {seg.fromName} → {seg.toName}
-                </div>
-                <div
-                  style={{ fontSize: 11, color: done ? "#22c55e" : "#60a5fa" }}
-                >
-                  {done ? "✓ Already marked" : "Click to mark this hop"}
-                </div>
-              </Tooltip>
-            </Polyline>
+            <React.Fragment key={seg.key}>
+              <Polyline
+                positions={seg.positions}
+                color={isHighlighted ? "#facc15" : done ? "#22c55e" : routeColor}
+                weight={isHighlighted ? 8 : done ? 6 : isHovered ? 6 : 4}
+                opacity={isHighlighted ? 1 : done ? 1 : isHovered ? 0.95 : 0.55}
+                eventHandlers={{
+                  click: () => handleSegmentClick(seg),
+                  mouseover: () => setHoverSeg(seg.key),
+                  mouseout: () =>
+                    setHoverSeg((h) => (h === seg.key ? null : h)),
+                }}
+              >
+                <Tooltip sticky direction="top" opacity={0.95}>
+                  <div style={{ fontWeight: 600, fontSize: 12 }}>
+                    {seg.fromName} → {seg.toName}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 11,
+                      color: done ? "#22c55e" : "#60a5fa",
+                    }}
+                  >
+                    {done ? "✓ Already marked" : "Click to mark this hop"}
+                  </div>
+                </Tooltip>
+              </Polyline>
+              {isFresh && (
+                <Polyline
+                  positions={seg.positions}
+                  color="#4ade80"
+                  weight={14}
+                  opacity={0.55}
+                  className="segment-pulse"
+                  interactive={false}
+                />
+              )}
+            </React.Fragment>
           );
         })}
 
@@ -834,6 +1061,28 @@ function TransitMap({
                   </span>
                 </div>
               )}
+              {!legendCollapsed && tripStats && (
+                <div
+                  className="map-legend-trip-stats"
+                  title="Average and most-recent ride time, measured between your boarding and alighting taps. Stored locally on this device."
+                >
+                  <span className="map-legend-trip-icon" aria-hidden>
+                    ⏱
+                  </span>
+                  <span>
+                    <strong>{formatDuration(tripStats.avgMs)}</strong> avg
+                    {tripStats.count > 1 ? ` (${tripStats.count} trips)` : ""}
+                    {tripStats.lastMs ? (
+                      <>
+                        {" · "}
+                        <span className="map-legend-trip-last">
+                          last {formatDuration(tripStats.lastMs)}
+                        </span>
+                      </>
+                    ) : null}
+                  </span>
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -860,6 +1109,14 @@ function TransitMap({
           </div>
           <span className="pick-arrow">→</span>
           <span className="pick-prompt">Now tap your alighting stop</span>
+          {pickState.boardedAt && (
+            <span
+              className="pick-timer"
+              title="Time since you tapped your boarding stop"
+            >
+              ⏱ {formatDuration(liveTripMs) || "0s"}
+            </span>
+          )}
           {activeDirectionMeta && (
             <span className="pick-direction-lock">
               Direction locked: {activeDirectionMeta.label}
@@ -900,6 +1157,28 @@ function TransitMap({
       {toast && (
         <div className={`map-toast map-toast-${toast.kind}`}>{toast.msg}</div>
       )}
+
+      <button
+        type="button"
+        className="map-help-button"
+        onClick={() => setHelpOpen(true)}
+        aria-label="How to use the map"
+        title="How to log a ride"
+      >
+        ?
+      </button>
+
+      <HelpModal
+        open={helpOpen}
+        onClose={() => setHelpOpen(false)}
+        onDontShowAgain={() => {
+          try {
+            localStorage.setItem(HELP_SEEN_KEY, "1");
+          } catch {
+            /* ignore */
+          }
+        }}
+      />
     </div>
   );
 }

--- a/tm-frontend/src/components/UserProgress.jsx
+++ b/tm-frontend/src/components/UserProgress.jsx
@@ -1,9 +1,58 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { updateSegmentNotes, bulkDeleteSegments } from "../services/api";
+import {
+  updateSegmentNotes,
+  updateSegmentDuration,
+  bulkDeleteSegments,
+} from "../services/api";
 import StatsCard from "./StatsCard";
 import Achievements from "./Achievements";
 import RecentActivity from "./RecentActivity";
 import ConfirmDialog from "./ConfirmDialog";
+
+function formatDurationMs(ms) {
+  if (ms == null || ms <= 0) return null;
+  const totalSec = Math.round(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min < 60) return sec ? `${min}m ${sec}s` : `${min}m`;
+  const hr = Math.floor(min / 60);
+  const remMin = min % 60;
+  return remMin ? `${hr}h ${remMin}m` : `${hr}h`;
+}
+
+function parseDurationInput(text) {
+  // Accept "12", "12m", "12m 30s", "1h 5m", "0:12:30", "12:30"
+  if (text == null) return null;
+  const t = String(text).trim().toLowerCase();
+  if (!t) return 0; // empty = clear
+  // colon form
+  if (/^\d+(:\d{1,2}){1,2}$/.test(t)) {
+    const parts = t.split(":").map((n) => parseInt(n, 10));
+    let h = 0,
+      m = 0,
+      s = 0;
+    if (parts.length === 3) [h, m, s] = parts;
+    else [m, s] = parts;
+    if (s >= 60 || m >= 60) return NaN;
+    return ((h * 3600 + m * 60 + s) * 1000) | 0;
+  }
+  // unit form
+  const re =
+    /(\d+(?:\.\d+)?)\s*(h|hr|hrs|hour|hours|m|min|mins|minute|minutes|s|sec|secs|second|seconds)?/g;
+  let total = 0;
+  let matched = false;
+  let m;
+  while ((m = re.exec(t)) !== null) {
+    matched = true;
+    const n = parseFloat(m[1]);
+    const unit = m[2] || "m"; // bare number defaults to minutes
+    if (/^h/.test(unit)) total += n * 3600 * 1000;
+    else if (/^s/.test(unit)) total += n * 1000;
+    else total += n * 60 * 1000;
+  }
+  return matched ? Math.round(total) : NaN;
+}
 
 /* Group consecutive same-direction hops into journey objects. */
 function groupIntoJourneys(segments) {
@@ -33,6 +82,10 @@ function groupIntoJourneys(segments) {
 function makeJourney(segs) {
   const first = segs[0];
   const last = segs[segs.length - 1];
+  // Duration is recorded only on the first row of a logged run, but if
+  // the user later edits a hop in the middle we still want to surface
+  // any non-null value here.
+  const durationSeg = segs.find((s) => s.duration_ms != null);
   return {
     key: `${first.direction_id}-${first.from_stop_id}-${last.to_stop_id}-${first.completed_at}`,
     directionId: first.direction_id,
@@ -49,6 +102,8 @@ function makeJourney(segs) {
           : undefined,
     }),
     notes: segs.find((s) => s.notes)?.notes || "",
+    durationMs: durationSeg ? durationSeg.duration_ms : null,
+    durationSegmentId: durationSeg ? durationSeg.id : first.id,
     segments: segs,
   };
 }
@@ -66,6 +121,10 @@ function UserProgress({
   const [expandedRoute, setExpandedRoute] = useState(null);
   const [editingNote, setEditingNote] = useState(null);
   const [noteText, setNoteText] = useState("");
+  const [editingDuration, setEditingDuration] = useState(null);
+  const [durationText, setDurationText] = useState("");
+  const [durationError, setDurationError] = useState("");
+  const [savingDuration, setSavingDuration] = useState(false);
   const [confirm, setConfirm] = useState(null); // { title, message, onConfirm, danger }
   const [view, setView] = useState("overview"); // overview | routes | achievements
   const routeRefs = useRef({});
@@ -130,6 +189,43 @@ function UserProgress({
     setEditingNote(null);
     setNoteText("");
     onRefresh();
+  };
+
+  const beginEditDuration = (journey) => {
+    setEditingDuration(journey.key);
+    setDurationText(
+      journey.durationMs != null ? formatDurationMs(journey.durationMs) : "",
+    );
+    setDurationError("");
+  };
+
+  const handleSaveDuration = async (journey) => {
+    const ms = parseDurationInput(durationText);
+    if (Number.isNaN(ms)) {
+      setDurationError(
+        "Use formats like 12m, 1h 5m, 12:30, or leave empty to clear.",
+      );
+      return;
+    }
+    if (ms < 0 || ms > 24 * 60 * 60 * 1000) {
+      setDurationError("Must be between 0 and 24h.");
+      return;
+    }
+    setSavingDuration(true);
+    try {
+      await updateSegmentDuration(
+        journey.durationSegmentId,
+        ms === 0 ? null : ms,
+      );
+      setEditingDuration(null);
+      setDurationText("");
+      setDurationError("");
+      onRefresh();
+    } catch (err) {
+      setDurationError(err?.message || "Could not save");
+    } finally {
+      setSavingDuration(false);
+    }
   };
 
   const askDeleteRide = (journey) =>
@@ -394,6 +490,14 @@ function UserProgress({
                             <span className="ride-direction-tag">
                               {journey.directionName}
                             </span>
+                            {journey.durationMs != null && (
+                              <span
+                                className="ride-duration-tag"
+                                title="Time spent on this ride"
+                              >
+                                ⏱ {formatDurationMs(journey.durationMs)}
+                              </span>
+                            )}
                             <span className="ride-date">{journey.date}</span>
                           </div>
 
@@ -468,6 +572,19 @@ function UserProgress({
                               {journey.notes ? "Edit note" : "Add note"}
                             </button>
                             <button
+                              className="btn-small"
+                              onClick={() => beginEditDuration(journey)}
+                              title={
+                                journey.durationMs != null
+                                  ? "Change recorded ride time"
+                                  : "Record how long this ride took"
+                              }
+                            >
+                              {journey.durationMs != null
+                                ? "Edit time"
+                                : "Add time"}
+                            </button>
+                            <button
                               className="btn-small btn-danger ride-delete"
                               onClick={() => askDeleteRide(journey)}
                               title="Remove this ride from your progress"
@@ -476,6 +593,56 @@ function UserProgress({
                               ✕
                             </button>
                           </div>
+
+                          {editingDuration === journey.key && (
+                            <div className="duration-edit">
+                              <label
+                                className="duration-edit-label"
+                                htmlFor={`dur-${journey.key}`}
+                              >
+                                Time on bus
+                              </label>
+                              <input
+                                id={`dur-${journey.key}`}
+                                type="text"
+                                inputMode="text"
+                                value={durationText}
+                                onChange={(e) => {
+                                  setDurationText(e.target.value);
+                                  if (durationError) setDurationError("");
+                                }}
+                                placeholder="e.g. 12m, 1h 5m, or 12:30"
+                                disabled={savingDuration}
+                              />
+                              {durationError && (
+                                <div className="duration-edit-error">
+                                  {durationError}
+                                </div>
+                              )}
+                              <div className="duration-edit-help">
+                                Leave empty to clear.
+                              </div>
+                              <div className="note-edit-actions">
+                                <button
+                                  className="btn-small btn-primary"
+                                  onClick={() => handleSaveDuration(journey)}
+                                  disabled={savingDuration}
+                                >
+                                  {savingDuration ? "Saving…" : "Save"}
+                                </button>
+                                <button
+                                  className="btn-small"
+                                  onClick={() => {
+                                    setEditingDuration(null);
+                                    setDurationError("");
+                                  }}
+                                  disabled={savingDuration}
+                                >
+                                  Cancel
+                                </button>
+                              </div>
+                            </div>
+                          )}
 
                           {editingNote === journey.key && (
                             <div className="note-edit">

--- a/tm-frontend/src/index.css
+++ b/tm-frontend/src/index.css
@@ -2226,9 +2226,9 @@ button {
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: var(--yellow);
+  background: var(--green);
   border: 3px solid #fff;
-  box-shadow: 0 0 12px rgba(250, 204, 21, 0.7);
+  box-shadow: 0 0 14px rgba(34, 197, 94, 0.85);
   position: relative;
 }
 .boarding-pulse-ring {
@@ -2238,7 +2238,7 @@ button {
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  border: 3px solid var(--yellow);
+  border: 3px solid var(--green);
   animation: boarding-pulse 1.4s ease-out infinite;
 }
 @keyframes boarding-pulse {

--- a/tm-frontend/src/index.css
+++ b/tm-frontend/src/index.css
@@ -998,7 +998,12 @@ button {
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
-  min-width: 150px;
+  /* Share width inside the 280px overlay rather than overflowing it.
+     The container already scrolls horizontally as a fallback if the
+     route happens to expose more than two directions. */
+  flex: 1 1 0;
+  min-width: 0;
+  text-align: left;
 }
 .direction-tab:hover {
   color: var(--text);
@@ -1012,6 +1017,10 @@ button {
   font-size: 13px;
   font-weight: 600;
   line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 .direction-tab-sub {
   font-size: 11px;
@@ -2574,7 +2583,8 @@ button {
   .app.sidebar-open .stop-search,
   .app.sidebar-open .leaflet-top.leaflet-left,
   .app.sidebar-open .leaflet-control-attribution,
-  .app.sidebar-open .mobile-current-route {
+  .app.sidebar-open .mobile-current-route,
+  .app.sidebar-open .map-help-button {
     display: none !important;
   }
 
@@ -3078,5 +3088,292 @@ button {
   }
   .pp-stats-row {
     grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* ── Trip-time stats inside the legend ──────────────────── */
+.map-legend-trip-stats {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-soft);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.map-legend-trip-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+.map-legend-trip-stats strong {
+  color: var(--text);
+}
+.map-legend-trip-last {
+  color: var(--text-faint);
+}
+
+/* ── Live trip timer in the pick overlay ────────────────── */
+.pick-timer {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: rgba(250, 204, 21, 0.14);
+  border: 1px solid rgba(250, 204, 21, 0.4);
+  color: #facc15;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* ── Floating "?" help button on the map ────────────────── */
+.map-help-button {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  z-index: 1000;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.92);
+  backdrop-filter: blur(8px);
+  color: var(--text);
+  font-size: 20px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: var(--shadow-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    transform 0.15s,
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+.map-help-button:hover {
+  transform: translateY(-1px);
+  background: var(--accent);
+  color: #0b1220;
+  border-color: var(--accent);
+}
+.map-help-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ── Recently-completed segment glow ────────────────────── */
+.segment-pulse {
+  animation: segment-pulse-fade 1.6s ease-out forwards;
+  pointer-events: none;
+}
+@keyframes segment-pulse-fade {
+  0% {
+    stroke-opacity: 0.85;
+    stroke-width: 18;
+  }
+  60% {
+    stroke-opacity: 0.5;
+    stroke-width: 14;
+  }
+  100% {
+    stroke-opacity: 0;
+    stroke-width: 6;
+  }
+}
+
+/* ── Help / onboarding modal ────────────────────────────── */
+.help-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.72);
+  backdrop-filter: blur(4px);
+  z-index: 5000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  animation: fade-in 0.2s ease;
+}
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.help-modal {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow-lg, 0 24px 48px rgba(0, 0, 0, 0.45));
+  width: 100%;
+  max-width: 540px;
+  max-height: calc(100dvh - 40px);
+  overflow-y: auto;
+  padding: 28px 28px 24px;
+  color: var(--text);
+  animation: pop-in 0.22s ease;
+}
+@keyframes pop-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+.help-modal-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.help-modal-close:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+.help-modal-title {
+  margin: 0 0 8px;
+  font-size: 22px;
+}
+.help-modal-lead {
+  margin: 0 0 18px;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+.help-modal-steps {
+  list-style: none;
+  margin: 0 0 18px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.help-modal-steps li {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 10px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  font-size: 13.5px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+.help-modal-steps li strong {
+  color: var(--text);
+}
+.help-modal-num {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #0b1220;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+}
+.help-modal-tip {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin-bottom: 14px;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+.help-modal-tip strong {
+  color: var(--text);
+  display: block;
+  margin-bottom: 6px;
+  font-size: 13px;
+}
+.help-modal-tip ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.help-modal-tip kbd {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 11px;
+  font-family: inherit;
+}
+.help-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 18px;
+  flex-wrap: wrap;
+}
+.help-modal-secondary,
+.help-modal-primary {
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text);
+  padding: 9px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+}
+.help-modal-secondary:hover {
+  border-color: var(--accent);
+}
+.help-modal-primary {
+  background: var(--accent);
+  color: #0b1220;
+  border-color: var(--accent);
+  font-weight: 600;
+}
+.help-modal-primary:hover {
+  filter: brightness(1.05);
+}
+
+@media (max-width: 600px) {
+  .help-modal {
+    padding: 22px 20px 20px;
+    border-radius: 14px;
+  }
+  .help-modal-title {
+    font-size: 19px;
+  }
+  /* Move the help button above the bottom-anchored map overlays so it
+     doesn't sit underneath them on phones. */
+  .map-help-button {
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
+    left: 12px;
+    width: 40px;
+    height: 40px;
   }
 }

--- a/tm-frontend/src/index.css
+++ b/tm-frontend/src/index.css
@@ -1826,6 +1826,59 @@ button {
   color: var(--text-faint);
   flex-shrink: 0;
 }
+.ride-duration-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: #facc15;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(250, 204, 21, 0.1);
+  border: 1px solid rgba(250, 204, 21, 0.3);
+  white-space: nowrap;
+}
+.duration-edit {
+  margin-top: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.duration-edit-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.duration-edit input {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+}
+.duration-edit input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 0;
+  border-color: var(--accent);
+}
+.duration-edit-help {
+  font-size: 11px;
+  color: var(--text-faint);
+}
+.duration-edit-error {
+  font-size: 11px;
+  color: var(--red, #f87171);
+}
 
 .ride-stops {
   display: flex;

--- a/tm-frontend/src/services/api.js
+++ b/tm-frontend/src/services/api.js
@@ -130,19 +130,27 @@ export const markSegments = async (
   fromStopId,
   toStopId,
   notes = "",
+  durationMs = null,
 ) => {
-  const r = await api.post("/api/me/segments", {
+  const payload = {
     route_id: routeId,
     direction_id: directionId,
     from_stop_id: fromStopId,
     to_stop_id: toStopId,
     notes,
-  });
+  };
+  if (durationMs != null) payload.duration_ms = durationMs;
+  const r = await api.post("/api/me/segments", payload);
   return r.data;
 };
 
 export const updateSegmentNotes = (segmentId, notes) =>
   api.put(`/api/me/segments/${segmentId}/notes`, { notes }).then((r) => r.data);
+
+export const updateSegmentDuration = (segmentId, durationMs) =>
+  api
+    .put(`/api/me/segments/${segmentId}/duration`, { duration_ms: durationMs })
+    .then((r) => r.data);
 
 export const deleteSegment = (segmentId) =>
   api.delete(`/api/me/segments/${segmentId}`).then((r) => r.data);


### PR DESCRIPTION
Summary of changes addressing each piece of feedback noted in https://github.com/cirillojon/transit-explorer/issues/4:

**"Nothing happens on the map line when a user clicks…it doesn't turn green after the click"** — added optimistic completion in TransitMap.jsx (optimisticDone set merged into effectiveCompleted immediately on POST, rolled back on error, dropped once server confirms). Polylines now flip to green the instant you tap the alighting stop, no refetch wait. As an extra cue, the boarding marker itself pulses green the moment you pick your starting stop (was yellow), so it's immediately obvious the click registered.

**"Route interaction & animation"** — added a `.segment-pulse` overlay polyline that briefly glows on top of each newly-green hop (1.6s fade in `index.css`), so you see the line animate from route-color to green.

**"Instruction modal should be more obvious"** — new `HelpModal.jsx` component shown automatically on first visit (gated by `te-help-seen-v1` localStorage), re-openable any time via a floating `?` `.map-help-button` in the bottom-left of the map. Modal walks through the 4-step flow, answers the "when do I tap?" question (tap-and-go vs after-the-fact), and lists shortcuts (Esc, segment-click, search).

**"When would they most likely click their route…"** — explicitly addressed in the help modal under "When should I log?" with both workflows.

**"Track time on route, average route time, time on bus"** — full client + server pipeline:

- Client-side trip timer (`te-trip-times-v1` localStorage, per route+direction, max 25 samples). Live `⏱ 3m 12s` chip appears in the boarding overlay; on save, the toast shows `✓ Marked 4 segments · 8m 21s on bus`. The legend shows `⏱ 7m avg (5 trips) · last 8m 21s`.
- Server-side persistence: new `user_segments.duration_ms` column (alembic rev `a1c2e4f9b701`), recorded on the first *newly-created* row of a multi-segment run to avoid double-counting, validated by `validate_duration_ms` (≤24h, rejects bool/non-numeric).
- Editable in Progress: each ride card shows a `⏱` chip plus an Add/Edit time button. Inline editor accepts `12m`, `1h 5m`, `12:30`, `0:12:30`, or empty to clear. Backed by `PUT /api/me/segments/<id>/duration` (auth + ownership-checked).
- Fixed a bug where the measured duration was silently dropped if the first hop of a run had already been marked on an earlier ride: `mark_segments` now attaches `duration_ms` to the first *new* row (tracked via a `first_new` flag), not the first iteration — so the `⏱` chip populates on Progress instead of showing "Add time" after a live timer.

**"Direction selector doesn't fit"** — `.direction-tab` switched from `min-width: 150px` to `flex: 1 1 0; min-width: 0;` with ellipsis on the label, so the two tabs share the 280px overlay cleanly.

**Deploy hardening** — `gunicorn_startup.sh` now runs migrations in a dedicated Python step (no stdout-parsing, no bash heredoc tricks) before gunicorn boots, then sets `SKIP_DB_UPGRADE=1` so the preloaded workers don't race on SQLite. `create_app()` self-heals legacy DBs (detects any baseline table without `alembic_version`, stamps baseline, then upgrades). The new migration uses plain `op.add_column` (batch_alter_table hangs on SQLite) and is idempotent so re-running on a partially-upgraded DB is a no-op.

**Tests:** 16/16 pytest (added two regressions for `duration_ms` persistence across fresh and partially-marked runs), 9/9 vitest passing.