### PR TITLE
Frontend improvements

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - transit-explorer  (2026-04-22)
 
 ## Corpus Check
-- 53 files · ~77,615 words
+- 53 files · ~77,712 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/tm-frontend/src/components/HelpModal.jsx
+++ b/tm-frontend/src/components/HelpModal.jsx
@@ -5,7 +5,7 @@ import React, { useEffect } from "react";
  * time a signed-in user lands on the app, and re-openable from the
  * floating "?" button on the map.
  */
-function HelpModal({ open, onClose, onDontShowAgain }) {
+function HelpModal({ open, onClose, onDontShowAgain, showDontShowAgain = false }) {
   useEffect(() => {
     if (!open) return;
     const onKey = (e) => {
@@ -102,16 +102,18 @@ function HelpModal({ open, onClose, onDontShowAgain }) {
         </div>
 
         <div className="help-modal-actions">
-          <button
-            type="button"
-            className="help-modal-secondary"
-            onClick={() => {
-              onDontShowAgain?.();
-              onClose?.();
-            }}
-          >
-            Don&apos;t show this again
-          </button>
+          {showDontShowAgain && (
+            <button
+              type="button"
+              className="help-modal-secondary"
+              onClick={() => {
+                onDontShowAgain?.();
+                onClose?.();
+              }}
+            >
+              Don&apos;t show this again
+            </button>
+          )}
           <button
             type="button"
             className="help-modal-primary"

--- a/tm-frontend/src/components/TransitMap.jsx
+++ b/tm-frontend/src/components/TransitMap.jsx
@@ -49,6 +49,7 @@ function TransitMap({
   const [optimisticDone, setOptimisticDone] = useState(() => new Set());
   const [recentlyDone, setRecentlyDone] = useState(() => new Set());
   const [helpOpen, setHelpOpen] = useState(false);
+  const [helpAutoOpened, setHelpAutoOpened] = useState(false);
   const [tripStatsTick, setTripStatsTick] = useState(0); // bumps to refresh avg
   const [liveTripMs, setLiveTripMs] = useState(0);
   const toastTimerRef = useRef(null);
@@ -94,7 +95,10 @@ function TransitMap({
   useEffect(() => {
     try {
       const seen = localStorage.getItem(HELP_SEEN_KEY);
-      if (!seen) setHelpOpen(true);
+      if (!seen) {
+        setHelpAutoOpened(true);
+        setHelpOpen(true);
+      }
     } catch {
       /* localStorage disabled — skip auto-open */
     }
@@ -790,20 +794,6 @@ function TransitMap({
         onUndo={undoBoarding}
       />
 
-      {/* Highlighted-from-progress banner */}
-      {highlightedSegment && !pickState && (
-        <div className="highlight-banner">
-          <span>📍 Viewing segment from progress</span>
-          <button
-            className="pick-cancel"
-            style={{ marginLeft: 10 }}
-            onClick={() => onClearHighlight?.()}
-          >
-            ✕
-          </button>
-        </div>
-      )}
-
       {toast && (
         <div className={`map-toast map-toast-${toast.kind}`}>{toast.msg}</div>
       )}
@@ -811,7 +801,10 @@ function TransitMap({
       <button
         type="button"
         className="map-help-button"
-        onClick={() => setHelpOpen(true)}
+        onClick={() => {
+          setHelpAutoOpened(false);
+          setHelpOpen(true);
+        }}
         aria-label="How to use the map"
         title="How to log a ride"
       >
@@ -820,6 +813,7 @@ function TransitMap({
 
       <HelpModal
         open={helpOpen}
+        showDontShowAgain={helpAutoOpened}
         onClose={() => setHelpOpen(false)}
         onDontShowAgain={() => {
           try {

--- a/tm-frontend/src/components/map/PickOverlay.jsx
+++ b/tm-frontend/src/components/map/PickOverlay.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { formatDuration } from "./mapUtils";
 
 function PickOverlay({
@@ -8,6 +8,13 @@ function PickOverlay({
   activeDirectionMeta,
   onUndo,
 }) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  // Reset to expanded whenever a new boarding pick begins.
+  useEffect(() => {
+    setCollapsed(false);
+  }, [pickState?.fromId]);
+
   if (marking) {
     return (
       <div className="pick-overlay">
@@ -16,6 +23,43 @@ function PickOverlay({
     );
   }
   if (!pickState) return null;
+
+  if (collapsed) {
+    return (
+      <div
+        className="pick-overlay is-collapsed"
+        role="button"
+        tabIndex={0}
+        onClick={() => setCollapsed(false)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setCollapsed(false);
+          }
+        }}
+      >
+        <span className="pick-dot boarding" />
+        <span className="pick-prompt">Tap ending stop</span>
+        {pickState.boardedAt && (
+          <span className="pick-timer" title="Time since boarding">
+            ⏱ {formatDuration(liveTripMs) || "0s"}
+          </span>
+        )}
+        <button
+          type="button"
+          className="pick-collapse-toggle"
+          aria-label="Expand boarding details"
+          onClick={(e) => {
+            e.stopPropagation();
+            setCollapsed(false);
+          }}
+        >
+          ▴
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="pick-overlay">
       <div className="pick-info">
@@ -48,6 +92,14 @@ function PickOverlay({
         title="Undo boarding (Esc)"
       >
         ↶ Undo boarding
+      </button>
+      <button
+        type="button"
+        className="pick-collapse-toggle"
+        aria-label="Minimize boarding details"
+        onClick={() => setCollapsed(true)}
+      >
+        ▾
       </button>
     </div>
   );

--- a/tm-frontend/src/components/map/StopMarkersLayer.jsx
+++ b/tm-frontend/src/components/map/StopMarkersLayer.jsx
@@ -106,7 +106,7 @@ function StopMarkersLayer({
             <>
               <br />
               <span style={{ fontSize: 11, color: "#22d3ee" }}>
-                Available to alight
+                Available ending stop
               </span>
             </>
           )}

--- a/tm-frontend/src/index.css
+++ b/tm-frontend/src/index.css
@@ -828,6 +828,30 @@ button {
   background: rgba(250, 204, 21, 0.08);
 }
 
+/* Minimize/expand chevron on the pick overlay. Hidden on desktop where
+   the overlay sits unobtrusively; shown on mobile where it can otherwise
+   block the map. See mobile media block below. */
+.pick-collapse-toggle {
+  display: none;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-left: 4px;
+}
+.pick-collapse-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 /* ── Stop search (overlay) ─────────────────────────────── */
 .stop-search {
   position: relative;
@@ -2370,26 +2394,6 @@ button {
   }
 }
 
-/* ── Highlighted segment banner ─────────────────────────── */
-.highlight-banner {
-  position: absolute;
-  bottom: 80px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 1000;
-  background: rgba(250, 204, 21, 0.12);
-  border: 1px solid var(--yellow);
-  color: var(--yellow);
-  padding: 8px 16px;
-  border-radius: 10px;
-  font-size: 13px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  white-space: nowrap;
-  box-shadow: var(--shadow-md);
-}
-
 /* ── Mobile (drawer) ───────────────────────────────────── */
 .mobile-sidebar-toggle {
   display: none;
@@ -2625,6 +2629,25 @@ button {
     white-space: normal;
     font-size: 13px;
   }
+  .pick-collapse-toggle {
+    display: inline-flex;
+  }
+  /* Collapsed pill: compact one-line summary the user can tap to expand. */
+  .pick-overlay.is-collapsed {
+    padding: 6px 10px;
+    gap: 8px;
+    flex-wrap: nowrap;
+    align-items: center;
+    cursor: pointer;
+    font-size: 12px;
+  }
+  .pick-overlay.is-collapsed .pick-prompt {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   @keyframes slide-up {
     from {
       opacity: 0;
@@ -2638,20 +2661,6 @@ button {
 
   .map-toast {
     top: calc(env(safe-area-inset-top, 0px) + 76px);
-  }
-
-  /* Anchor the highlight banner to the top on mobile so it can't overlap
-     the bottom-anchored route details / legend stack. Sits just below the
-     mobile route badge (top + 12 + 54px height + 10 gap ≈ 76px). */
-  .highlight-banner {
-    top: calc(env(safe-area-inset-top, 0px) + 76px);
-    bottom: auto;
-    left: 12px;
-    right: 12px;
-    transform: none;
-    white-space: normal;
-    text-align: center;
-    justify-content: center;
   }
 
   /* Achievement toasts: keep them on the left side at the bottom on mobile
@@ -2703,8 +2712,7 @@ button {
 
   /* Tame Leaflet's attribution on phones — by default it lives flush
      bottom-right and visually collides with the stop-search row /
-     legend pill. Make it small, slightly transparent, and push it
-     above the iOS home-indicator safe area. */
+     legend pill. Makme-indicator safe area. */
   .leaflet-control-attribution {
     font-size: 9px !important;
     line-height: 1.2 !important;
@@ -3481,11 +3489,14 @@ button {
   .help-modal-title {
     font-size: 19px;
   }
-  /* Move the help button above the bottom-anchored map overlays so it
-     doesn't sit underneath them on phones. */
+  /* Move the help button to the top-right on phones so it doesn't sit
+     under bottom-anchored map overlays (legend, pick prompt, popup
+     toasts). Sits below the mobile route badge (top + 12 + 54 + 12). */
   .map-help-button {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
-    left: 12px;
+    top: calc(env(safe-area-inset-top, 0px) + 78px);
+    right: 12px;
+    bottom: auto;
+    left: auto;
     width: 40px;
     height: 40px;
   }


### PR DESCRIPTION
Summary
All 4 issues addressed in TransitMap.jsx, HelpModal.jsx, PickOverlay.jsx, and index.css:

#30 — Removed the "📍 Viewing segment from progress" banner JSX and all .highlight-banner CSS (desktop, mobile, and .sidebar-open hide rule). The existing auto-clear useEffect in App.jsx keeps the highlight scoped to the Progress tab.
#12 — HelpModal now takes showDontShowAgain (default false); button is conditionally rendered. TransitMap tracks a helpAutoOpened flag — true only on the first-visit auto-open, false when the ? button is clicked.
#17 — On mobile (@media (max-width: 600px)), .map-help-button now pins to top-right (top: env(safe-area-inset-top) + 78px; right: 12px), under the route badge and clear of .map-legend / .popup-toast at the bottom.
#27 — PickOverlay gained a mobile-only collapse chevron. Default expanded; tap ▾ → collapses to a one-line pill (dot · "Tap ending stop" · timer · ▴); tap pill or expand button to restore. Esc/undo behavior unchanged. New CSS .pick-collapse-toggle is display: none on desktop, inline-flex on mobile, with .pick-overlay.is-collapsed pill styling.