### PR TITLE
address issue 38

### DIFF
--- a/tm-frontend/src/components/map/mapUtils.js
+++ b/tm-frontend/src/components/map/mapUtils.js
@@ -122,18 +122,43 @@ function distSq(a, b) {
   return (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2;
 }
 
-// Find the polyline index closest to `point`. Returns { index, dSq }.
+// Squared perpendicular distance from `point` to the segment a→b.
+// Treats lat/lon as planar — fine for the small-area off-route check.
+function pointToSegmentDistSq(point, a, b) {
+  const dx = b[0] - a[0];
+  const dy = b[1] - a[1];
+  const len2 = dx * dx + dy * dy;
+  if (len2 === 0) return distSq(point, a);
+  let t = ((point[0] - a[0]) * dx + (point[1] - a[1]) * dy) / len2;
+  if (t < 0) t = 0;
+  else if (t > 1) t = 1;
+  const projX = a[0] + t * dx;
+  const projY = a[1] + t * dy;
+  return (point[0] - projX) ** 2 + (point[1] - projY) ** 2;
+}
+
+// Find the polyline vertex index closest to `point`. Returns the vertex
+// index plus the squared perpendicular distance to the *polyline itself*
+// (not just to the nearest vertex). Using perpendicular distance for the
+// off-route check matters for routes like rail/Sounder where vertices can
+// be kilometers apart along a straight stretch — a station sitting right
+// on the line can still be far from any single vertex.
 function nearestIndex(line, point) {
-  let best = 0;
-  let bestDist = Infinity;
+  let bestIdx = 0;
+  let bestVertexDist = Infinity;
   for (let i = 0; i < line.length; i++) {
     const d = distSq(line[i], point);
-    if (d < bestDist) {
-      bestDist = d;
-      best = i;
+    if (d < bestVertexDist) {
+      bestVertexDist = d;
+      bestIdx = i;
     }
   }
-  return { index: best, dSq: bestDist };
+  let bestSegDist = bestVertexDist;
+  for (let i = 0; i < line.length - 1; i++) {
+    const d = pointToSegmentDistSq(point, line[i], line[i + 1]);
+    if (d < bestSegDist) bestSegDist = d;
+  }
+  return { index: bestIdx, dSq: bestSegDist };
 }
 
 /**


### PR DESCRIPTION
To address https://github.com/cirillojon/transit-explorer/issues/38:

**Root cause:** `nearestIndex` was measuring the squared distance from each stop to the closest polyline **vertex**, then comparing it against `OFF_ROUTE_THRESHOLD_DEG_SQ` (~150 m). For rail/Sounder routes, the encoded polyline often has only a handful of vertices over long straight stretches — adjacent vertices can be kilometers apart. A station that sits exactly on the line between two distant vertices was therefore measured as far from the polyline, flagged as off-route, and `slicePolylineByStops` returned `null` for every hop touching it. Both `directionSegments` and `allRouteSegments` then skipped those hops, so the rail polylines disappeared.

**Fix in mapUtils.js:**
- Added `pointToSegmentDistSq` (perpendicular distance from a point to a line segment, planar approx — fine at the threshold scale).
- `nearestIndex` still returns the nearest **vertex** (used as the slice boundary), but `dSq` is now the true perpendicular distance to the **polyline** (used for the off-route check).

This decouples "which vertex to slice at" from "is this stop actually on the line", so a station on a long inter-vertex stretch is correctly recognized as on-route. All bus-3 / 2-Line / dense-urban test cases still behave the same because for those scenarios the vertex distance and perpendicular distance agree (or both fail the threshold).