### PR TITLE
dont force close details code when selecting in-progress route

### DIFF
--- a/tm-frontend/src/App.jsx
+++ b/tm-frontend/src/App.jsx
@@ -113,8 +113,8 @@ function App() {
       if (route) {
         setSelectedRoute(route);
         setAllProgressDetails(null);
-        // On mobile the sidebar covers the map; close it so the route is visible.
-        setSidebarOpen(false);
+        // Keep the sidebar open on mobile — the user wants the route highlighted
+        // on the map but shouldn't lose the in-progress details card.
       }
     },
     [routes],


### PR DESCRIPTION
 Removed `setSidebarOpen(false)` from `handleSelectRouteFromProgress`. Now tapping a route in the in-progress list on mobile will still load/highlight it on the map, but the details card stays open instead of force-closing.