### PR TITLE
Show progress on route immediately, and have it persist

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - transit-explorer  (2026-04-23)
 
 ## Corpus Check
-- 60 files · ~95,511 words
+- 60 files · ~95,965 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -517,9 +517,9 @@
       "file_type": "rationale",
       "source_file": "app/models.py",
       "source_location": "L196",
-      "id": "models_rationale_196",
       "community": 0,
-      "norm_label": "per-agency snapshot of the last onebusaway data import.      one row per agency."
+      "norm_label": "per-agency snapshot of the last onebusaway data import.      one row per agency.",
+      "id": "models_rationale_196"
     },
     {
       "label": "oba_service.py",
@@ -1237,18 +1237,18 @@
       "file_type": "rationale",
       "source_file": "app/routes/api.py",
       "source_location": "L917",
-      "id": "api_rationale_917",
       "community": 0,
-      "norm_label": "aggregate stats for a user \u2014 used by /me, /me/stats, achievement diffing."
+      "norm_label": "aggregate stats for a user \u2014 used by /me, /me/stats, achievement diffing.",
+      "id": "api_rationale_917"
     },
     {
       "label": "Achievements that flipped locked\u2192unlocked between two summary snapshots.",
       "file_type": "rationale",
       "source_file": "app/routes/api.py",
       "source_location": "L974",
-      "id": "api_rationale_974",
       "community": 0,
-      "norm_label": "achievements that flipped locked\u2192unlocked between two summary snapshots."
+      "norm_label": "achievements that flipped locked\u2192unlocked between two summary snapshots.",
+      "id": "api_rationale_974"
     },
     {
       "label": "__init__.py",
@@ -4803,11 +4803,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_917",
-      "_tgt": "models_user",
+      "_src": "models_user",
+      "_tgt": "api_rationale_917",
+      "confidence_score": 0.5,
       "source": "models_user",
-      "target": "api_rationale_917",
-      "confidence_score": 0.5
+      "target": "api_rationale_917"
     },
     {
       "relation": "uses",
@@ -4815,11 +4815,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_974",
-      "_tgt": "models_user",
+      "_src": "models_user",
+      "_tgt": "api_rationale_974",
+      "confidence_score": 0.5,
       "source": "models_user",
-      "target": "api_rationale_974",
-      "confidence_score": 0.5
+      "target": "api_rationale_974"
     },
     {
       "relation": "uses",
@@ -5595,11 +5595,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_917",
-      "_tgt": "models_route",
+      "_src": "models_route",
+      "_tgt": "api_rationale_917",
+      "confidence_score": 0.5,
       "source": "models_route",
-      "target": "api_rationale_917",
-      "confidence_score": 0.5
+      "target": "api_rationale_917"
     },
     {
       "relation": "uses",
@@ -5607,11 +5607,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_974",
-      "_tgt": "models_route",
+      "_src": "models_route",
+      "_tgt": "api_rationale_974",
+      "confidence_score": 0.5,
       "source": "models_route",
-      "target": "api_rationale_974",
-      "confidence_score": 0.5
+      "target": "api_rationale_974"
     },
     {
       "relation": "uses",
@@ -6399,11 +6399,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_917",
-      "_tgt": "models_stop",
+      "_src": "models_stop",
+      "_tgt": "api_rationale_917",
+      "confidence_score": 0.5,
       "source": "models_stop",
-      "target": "api_rationale_917",
-      "confidence_score": 0.5
+      "target": "api_rationale_917"
     },
     {
       "relation": "uses",
@@ -6411,11 +6411,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_974",
-      "_tgt": "models_stop",
+      "_src": "models_stop",
+      "_tgt": "api_rationale_974",
+      "confidence_score": 0.5,
       "source": "models_stop",
-      "target": "api_rationale_974",
-      "confidence_score": 0.5
+      "target": "api_rationale_974"
     },
     {
       "relation": "uses",
@@ -7179,11 +7179,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_917",
-      "_tgt": "models_routedirection",
+      "_src": "models_routedirection",
+      "_tgt": "api_rationale_917",
+      "confidence_score": 0.5,
       "source": "models_routedirection",
-      "target": "api_rationale_917",
-      "confidence_score": 0.5
+      "target": "api_rationale_917"
     },
     {
       "relation": "uses",
@@ -7191,11 +7191,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_974",
-      "_tgt": "models_routedirection",
+      "_src": "models_routedirection",
+      "_tgt": "api_rationale_974",
+      "confidence_score": 0.5,
       "source": "models_routedirection",
-      "target": "api_rationale_974",
-      "confidence_score": 0.5
+      "target": "api_rationale_974"
     },
     {
       "relation": "uses",
@@ -7947,11 +7947,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_917",
-      "_tgt": "models_routestop",
+      "_src": "models_routestop",
+      "_tgt": "api_rationale_917",
+      "confidence_score": 0.5,
       "source": "models_routestop",
-      "target": "api_rationale_917",
-      "confidence_score": 0.5
+      "target": "api_rationale_917"
     },
     {
       "relation": "uses",
@@ -7959,11 +7959,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_974",
-      "_tgt": "models_routestop",
+      "_src": "models_routestop",
+      "_tgt": "api_rationale_974",
+      "confidence_score": 0.5,
       "source": "models_routestop",
-      "target": "api_rationale_974",
-      "confidence_score": 0.5
+      "target": "api_rationale_974"
     },
     {
       "relation": "uses",
@@ -8607,11 +8607,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_917",
-      "_tgt": "models_usersegment",
+      "_src": "models_usersegment",
+      "_tgt": "api_rationale_917",
+      "confidence_score": 0.5,
       "source": "models_usersegment",
-      "target": "api_rationale_917",
-      "confidence_score": 0.5
+      "target": "api_rationale_917"
     },
     {
       "relation": "uses",
@@ -8619,11 +8619,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L4",
       "weight": 0.8,
-      "_src": "api_rationale_974",
-      "_tgt": "models_usersegment",
+      "_src": "models_usersegment",
+      "_tgt": "api_rationale_974",
+      "confidence_score": 0.5,
       "source": "models_usersegment",
-      "target": "api_rationale_974",
-      "confidence_score": 0.5
+      "target": "api_rationale_974"
     },
     {
       "relation": "uses",
@@ -9411,11 +9411,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L54",
       "weight": 0.8,
-      "_src": "api_rationale_917",
-      "_tgt": "models_dataload",
+      "_src": "models_dataload",
+      "_tgt": "api_rationale_917",
+      "confidence_score": 0.5,
       "source": "models_dataload",
-      "target": "api_rationale_917",
-      "confidence_score": 0.5
+      "target": "api_rationale_917"
     },
     {
       "relation": "uses",
@@ -9423,11 +9423,11 @@
       "source_file": "app/routes/api.py",
       "source_location": "L54",
       "weight": 0.8,
-      "_src": "api_rationale_974",
-      "_tgt": "models_dataload",
+      "_src": "models_dataload",
+      "_tgt": "api_rationale_974",
+      "confidence_score": 0.5,
       "source": "models_dataload",
-      "target": "api_rationale_974",
-      "confidence_score": 0.5
+      "target": "api_rationale_974"
     },
     {
       "relation": "uses",

--- a/tm-frontend/src/App.jsx
+++ b/tm-frontend/src/App.jsx
@@ -141,6 +141,47 @@ function App() {
     }
   }, [user]);
 
+  // Called by TransitMap after a segment is successfully marked.
+  // Immediately merges the newly created segments into `progress` (using the
+  // exact same key format as `completedSegments`) so the map stays green
+  // without waiting for a full server round-trip. The full refresh runs in
+  // the background to pick up accurate completion stats, achievements, etc.
+  const handleSegmentsMarked = useCallback(
+    (result) => {
+      if (result?.segments?.length) {
+        setProgress((prev) => {
+          const newSegs = result.segments;
+          const byRoute = {};
+          for (const seg of newSegs) {
+            if (!byRoute[seg.route_id]) byRoute[seg.route_id] = [];
+            byRoute[seg.route_id].push(seg);
+          }
+          return prev.map((rp) => {
+            const extra = byRoute[rp.route_id];
+            if (!extra) return rp;
+            const existingKeys = new Set(
+              rp.segments.map(
+                (s) => `${s.direction_id}|${s.from_stop_id}|${s.to_stop_id}`,
+              ),
+            );
+            const toAdd = extra.filter(
+              (s) =>
+                !existingKeys.has(
+                  `${s.direction_id}|${s.from_stop_id}|${s.to_stop_id}`,
+                ),
+            );
+            return toAdd.length
+              ? { ...rp, segments: [...rp.segments, ...toAdd] }
+              : rp;
+          });
+        });
+      }
+      // Full refresh for accurate completion %, rank, activity feed, etc.
+      loadUserData();
+    },
+    [loadUserData],
+  );
+
   const handleShowAllProgressRoutes = useCallback(async () => {
     if (!progress.length) return;
     const results = await Promise.allSettled(
@@ -464,7 +505,7 @@ function App() {
       <TransitMap
         selectedRoute={selectedRoute}
         completedSegments={completedSegments}
-        onSegmentsMarked={loadUserData}
+        onSegmentsMarked={handleSegmentsMarked}
         highlightedSegment={highlightedSegment}
         onClearHighlight={() => setHighlightedSegment(null)}
         onUnlockToast={pushToast}

--- a/tm-frontend/src/components/map/AllRouteSegmentsLayer.jsx
+++ b/tm-frontend/src/components/map/AllRouteSegmentsLayer.jsx
@@ -16,9 +16,14 @@ function AllRouteSegmentsLayer({
       <Polyline
         key={seg.key}
         positions={seg.positions}
-        color={done ? "#22c55e" : seg.color}
-        weight={done ? 5 : 3}
-        opacity={done ? 0.85 : 0.45}
+        // See RouteSegmentsLayer: react-leaflet v5 only reactively updates
+        // styling via `pathOptions`; direct color/weight/opacity props are
+        // applied at mount only.
+        pathOptions={{
+          color: done ? "#22c55e" : seg.color,
+          weight: done ? 5 : 3,
+          opacity: done ? 0.85 : 0.45,
+        }}
       >
         {routeInfo && (
           <Tooltip sticky pane="tooltipPane">

--- a/tm-frontend/src/components/map/RouteSegmentsLayer.jsx
+++ b/tm-frontend/src/components/map/RouteSegmentsLayer.jsx
@@ -23,13 +23,19 @@ function RouteSegmentsLayer({
         `${highlightedSegment.routeId}|${highlightedSegment.directionId}|${highlightedSegment.fromStopId}|${highlightedSegment.toStopId}`;
     const isHovered = hoverSeg === seg.key;
     const isFresh = recentlyDone.has(seg.key);
+    const color = isHighlighted ? "#facc15" : done ? "#22c55e" : routeColor;
+    const weight = isHighlighted ? 8 : done ? 6 : isHovered ? 6 : 4;
+    const opacity = isHighlighted ? 1 : done ? 1 : isHovered ? 0.95 : 0.55;
     return (
       <React.Fragment key={seg.key}>
         <Polyline
           positions={seg.positions}
-          color={isHighlighted ? "#facc15" : done ? "#22c55e" : routeColor}
-          weight={isHighlighted ? 8 : done ? 6 : isHovered ? 6 : 4}
-          opacity={isHighlighted ? 1 : done ? 1 : isHovered ? 0.95 : 0.55}
+          // react-leaflet v5 only reactively updates style via `pathOptions`;
+          // passing color/weight/opacity as direct props applies them at
+          // mount only and skips later updates, so a polyline that turns
+          // "done" after the initial render would otherwise stay the route
+          // color until the layer is remounted.
+          pathOptions={{ color, weight, opacity }}
           eventHandlers={{
             click: () => onSegmentClick(seg),
             mouseover: () => setHoverSeg(seg.key),


### PR DESCRIPTION
Found the real bug — it wasn't the data flow (that was already correct after my last fix). It was a **react-leaflet v5 quirk**: `<Polyline>` styling props (`color`, `weight`, `opacity`) are passed to Leaflet at mount time only and are **not reactively updated** when their values change. The "green" you saw was the temporary `recentlyDone` pulse polyline (a separate, freshly-mounted overlay); when it unmounted after 1.6s, the base polyline beneath it was still showing its mount-time route color (yellow on Route 1). Switching routes worked because it forces a remount with the new color.

The fix passes styles via `pathOptions={{...}}` instead, which react-leaflet v5 *does* watch for changes. Applied in both RouteSegmentsLayer.jsx and AllRouteSegmentsLayer.jsx.

Now the green should stick immediately on mark, no route-toggle needed.