### PR TITLE
add direction arrows

### DIFF
--- a/tm-frontend/src/components/map/DirectionTabs.jsx
+++ b/tm-frontend/src/components/map/DirectionTabs.jsx
@@ -1,5 +1,22 @@
 import React from "react";
 
+// Fallback arrow when the route detail didn't supply a precomputed one
+// (no stop coordinates available). Uses keywords from the agency-supplied
+// direction label and biases the two boxes to opposites by index.
+function fallbackArrow(label, index) {
+  const text = (label || "").toLowerCase();
+  const has = (...words) => words.some((w) => text.includes(w));
+  if (has("north", "northbound", " nb", "n-bound")) return "↑";
+  if (has("south", "southbound", " sb", "s-bound")) return "↓";
+  if (has("east", "eastbound", " eb", "e-bound")) return "→";
+  if (has("west", "westbound", " wb", "w-bound")) return "←";
+  if (has("inbound", "downtown", "uptown bound")) return "→";
+  if (has("outbound")) return "←";
+  if (has("up")) return "↑";
+  if (has("down")) return "↓";
+  return index === 0 ? "↑" : "↓";
+}
+
 function DirectionTabs({
   directionChoices,
   resolvedDirectionId,
@@ -8,24 +25,32 @@ function DirectionTabs({
 }) {
   return (
     <div className={`direction-tabs ${hasLockedDirection ? "is-locked" : ""}`}>
-      {directionChoices.map((dir) => (
-        <button
-          key={dir.directionId}
-          className={`direction-tab ${resolvedDirectionId === dir.directionId ? "active" : ""} ${hasLockedDirection && resolvedDirectionId === dir.directionId ? "locked" : ""} ${hasLockedDirection && resolvedDirectionId !== dir.directionId ? "inactive" : ""}`.trim()}
-          onClick={() => onSelect(dir.directionId)}
-        >
-          <span className="direction-tab-label">{dir.label}</span>
-          <span className="direction-tab-sub" title={dir.lastStopName || ""}>
-            {hasLockedDirection && resolvedDirectionId === dir.directionId
-              ? dir.lastStopName
-                ? `Locked toward ${dir.lastStopName}`
-                : "Locked for current trip"
-              : dir.lastStopName
-                ? `Toward ${dir.lastStopName}`
-                : "Tap to follow this direction"}
-          </span>
-        </button>
-      ))}
+      {directionChoices.map((dir, idx) => {
+        const arrow = dir.arrow || fallbackArrow(dir.label, idx);
+        return (
+          <button
+            key={dir.directionId}
+            className={`direction-tab ${resolvedDirectionId === dir.directionId ? "active" : ""} ${hasLockedDirection && resolvedDirectionId === dir.directionId ? "locked" : ""} ${hasLockedDirection && resolvedDirectionId !== dir.directionId ? "inactive" : ""}`.trim()}
+            onClick={() => onSelect(dir.directionId)}
+          >
+            <span className="direction-tab-label">
+              <span className="direction-tab-arrow" aria-hidden="true">
+                {arrow}
+              </span>
+              {dir.label}
+            </span>
+            <span className="direction-tab-sub" title={dir.lastStopName || ""}>
+              {hasLockedDirection && resolvedDirectionId === dir.directionId
+                ? dir.lastStopName
+                  ? `Locked toward ${dir.lastStopName}`
+                  : "Locked for current trip"
+                : dir.lastStopName
+                  ? `Toward ${dir.lastStopName}`
+                  : "Tap to follow this direction"}
+            </span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/tm-frontend/src/components/map/hooks/useRouteDetail.js
+++ b/tm-frontend/src/components/map/hooks/useRouteDetail.js
@@ -2,6 +2,57 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { fetchRouteDetail, invalidateCache } from "../../../services/api";
 import { normalizeDirectionId } from "../mapUtils";
 
+// Pick a compass-style arrow for a direction, biased toward N/S.
+//
+// Most transit lines run roughly north–south or east–west, but real bus
+// routes wander, so a strict 8-way compass split puts a lot of mostly-
+// vertical routes onto a diagonal arrow. We widen the N/S sectors to
+// ~80° each and shrink the E/W sectors to ~30° so anything that's
+// "mostly down" reads as ↓.
+//
+// Falls back to keyword detection on the agency-supplied direction name
+// when stops don't have coordinates.
+function directionArrowFromStops(firstStop, lastStop, label) {
+  const lat1 = firstStop?.lat;
+  const lon1 = firstStop?.lon;
+  const lat2 = lastStop?.lat;
+  const lon2 = lastStop?.lon;
+  const haveCoords = [lat1, lon1, lat2, lon2].every(
+    (v) => typeof v === "number" && Number.isFinite(v),
+  );
+  if (haveCoords) {
+    const dy = lat2 - lat1; // +north
+    // Correct longitude for latitude so a degree of lon ~ a degree of lat.
+    const meanLatRad = ((lat1 + lat2) / 2) * (Math.PI / 180);
+    const dx = (lon2 - lon1) * Math.cos(meanLatRad); // +east
+    if (Math.abs(dx) > 1e-9 || Math.abs(dy) > 1e-9) {
+      // Angle from north, in degrees, 0..180. Sign of dx picks E vs W.
+      const angle = (Math.atan2(Math.abs(dx), dy) * 180) / Math.PI;
+      const east = dx >= 0;
+      // N/S sectors: ±40° around N (0) and ±40° around S (180).
+      // E/W sectors: 75°–105° from north.
+      // Diagonals fill the gaps (40°–75° and 105°–140°).
+      if (angle <= 40) return "↑";
+      if (angle >= 140) return "↓";
+      if (angle >= 75 && angle <= 105) return east ? "→" : "←";
+      if (angle < 75) return east ? "↗" : "↖";
+      return east ? "↘" : "↙";
+    }
+  }
+  // Keyword fallback when geometry is missing or degenerate.
+  const text = (label || "").toLowerCase();
+  const has = (...words) => words.some((w) => text.includes(w));
+  if (has("north", "northbound", " nb", "n-bound")) return "↑";
+  if (has("south", "southbound", " sb", "s-bound")) return "↓";
+  if (has("east", "eastbound", " eb", "e-bound")) return "→";
+  if (has("west", "westbound", " wb", "w-bound")) return "←";
+  if (has("inbound", "downtown", "uptown bound")) return "→";
+  if (has("outbound")) return "←";
+  if (has("up")) return "↑";
+  if (has("down")) return "↓";
+  return null;
+}
+
 /**
  * Loads the full detail payload for the currently selected route and
  * tracks which direction the UI is focused on.
@@ -85,6 +136,7 @@ export default function useRouteDetail(selectedRoute, { onLoadError } = {}) {
         label: dir.direction_name || `Direction ${dir.direction_id}`,
         firstStopName: firstStop?.name || null,
         lastStopName: lastStop?.name || null,
+        arrow: directionArrowFromStops(firstStop, lastStop, dir.direction_name),
       };
     });
   }, [routeDetail]);

--- a/tm-frontend/src/index.css
+++ b/tm-frontend/src/index.css
@@ -1073,6 +1073,9 @@ button {
   color: rgba(4, 21, 31, 0.78);
 }
 .direction-tab-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-size: 13px;
   font-weight: 600;
   line-height: 1.2;
@@ -1080,6 +1083,22 @@ button {
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
+}
+.direction-tab-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  font-size: 14px;
+  line-height: 1;
+  font-weight: 700;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.direction-tab.active .direction-tab-arrow,
+.direction-tab.locked .direction-tab-arrow {
+  color: inherit;
 }
 .direction-tab-sub {
   font-size: 11px;


### PR DESCRIPTION

<img width="396" height="86" alt="image" src="https://github.com/user-attachments/assets/9e10e4f0-78a3-4d71-b84b-c41c72ab36ed" />

```
- useRouteDetail.js: added `directionArrowFromStops()` and attach `arrow` to each `directionChoices` entry. It computes the bearing from the first stop to the last stop using lat/lon (with longitude scaled by `cos(meanLat)` so the planar approximation is honest), then maps to one of `↑ ↗ → ↘ ↓ ↙ ← ↖` using widened N/S sectors:
	- Within 40° of north → `↑`
	- Within 40° of south → `↓`
	- 75°–105° from north → `→` / `←`
	- Otherwise diagonal (`↗ ↘ ↖ ↙`)
- DirectionTabs.jsx: consumes `dir.arrow` first and only falls back to keyword/index detection if geometry was unavailable.

Net effect: a route that's "mostly down" (e.g., heads slightly east while running predominantly south) will now read as `↓` instead of `↘`, while truly diagonal routes still get a diagonal arrow.